### PR TITLE
Add list_directories and list_pages to containers

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -28,6 +28,8 @@ from base64 import b64encode
 from datetime import datetime, timedelta
 from socketserver import TCPServer
 from http.server import SimpleHTTPRequestHandler
+from dotenv import load_dotenv
+from os import getenv
 
 import selenium.webdriver as webdriver
 
@@ -82,9 +84,6 @@ class Client:
         super().__init__()
 
         if base_url is None or akid is None or akpass is None:
-            from dotenv import load_dotenv
-            from os import getenv
-
             load_dotenv()
 
             if base_url is None:

--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping, MutableSequence, Sequence, ValuesView
 from datetime import datetime
-from typing import TYPE_CHECKING, Self, overload, override
+from time import monotonic
+from typing import TYPE_CHECKING, Literal, Self, overload, override
 
 from labapi.util import IdIndex, IdOrNameIndex, Index, NameIndex, extract_etree, to_bool
 
@@ -258,6 +259,7 @@ class AbstractTreeContainer(
         """
         super().__init__(tree_id, name, root, parent, user)
         self._children: MutableSequence[AbstractTreeNode] = []
+        self._populated: bool = False
 
     @property
     def children(self) -> Sequence[AbstractTreeNode]:
@@ -277,7 +279,7 @@ class AbstractTreeContainer(
         """
         from . import directory, page
 
-        if len(self.children) == 0:
+        if not self._populated:
             xml_tree = self.user.api_get(
                 "tree_tools/get_tree_level",
                 nbid=self.root.id,
@@ -310,6 +312,7 @@ class AbstractTreeContainer(
                     nodes.append(directory.NotebookDirectory(*args))
 
             self._children = nodes
+            self._populated = True
 
     def __len__(self) -> int:
         self._ensure_populated()
@@ -369,6 +372,136 @@ class AbstractTreeContainer(
     # TODO
     # FIXME
     # need an indexing by relative url thing
+
+    @overload
+    def list_directories(
+        self,
+        *,
+        recursive: bool = False,
+        as_dict: Literal[False] = False,
+        timeout: float | None = None,
+    ) -> list[str]: ...
+
+    @overload
+    def list_directories(
+        self,
+        *,
+        recursive: bool = False,
+        as_dict: Literal[True],
+        timeout: float | None = None,
+    ) -> dict[str, NotebookDirectory]: ...
+
+    def list_directories(
+        self,
+        *,
+        recursive: bool = False,
+        as_dict: bool = False,
+        timeout: float | None = None,
+        _deadline: float | None = None,
+    ) -> list[str] | dict[str, NotebookDirectory]:
+        """Lists subdirectories within this container.
+
+        :param recursive: If True, includes all subdirectories at every level.
+                          Recursive entries are keyed/named with their full relative path.
+        :type recursive: bool
+        :param as_dict: If True, returns a dict mapping names to directory objects.
+                        If False, returns a list of names.
+        :type as_dict: bool
+        :param timeout: Maximum seconds allowed for recursive traversal.
+                        Defaults to 10 when recursive is True, ignored otherwise.
+        :type timeout: float or None
+        :returns: A list of directory names or a dict of ``{name: NotebookDirectory}``.
+        :rtype: list[str] or dict[str, NotebookDirectory]
+        :raises TimeoutError: If the recursive traversal exceeds the timeout.
+        """
+        if recursive and _deadline is None:
+            _deadline = monotonic() + (timeout if timeout is not None else 10)
+
+        self._ensure_populated()
+
+        results: dict[str, NotebookDirectory] = {}
+
+        for child in self.children:
+            if child.is_dir():
+                results[child.name] = child  # type: ignore[assignment]
+                if recursive and isinstance(child, AbstractTreeContainer):
+                    if _deadline is not None and monotonic() > _deadline:
+                        raise TimeoutError(
+                            "list_directories recursive traversal timed out"
+                        )
+                    for sub_name, sub_dir in child.list_directories(
+                        recursive=True, as_dict=True, _deadline=_deadline
+                    ).items():
+                        results[f"{child.name}/{sub_name}"] = sub_dir
+
+        if as_dict:
+            return results
+        return list(results.keys())
+
+    @overload
+    def list_pages(
+        self,
+        *,
+        recursive: bool = False,
+        as_dict: Literal[False] = False,
+        timeout: float | None = None,
+    ) -> list[str]: ...
+
+    @overload
+    def list_pages(
+        self,
+        *,
+        recursive: bool = False,
+        as_dict: Literal[True],
+        timeout: float | None = None,
+    ) -> dict[str, NotebookPage]: ...
+
+    def list_pages(
+        self,
+        *,
+        recursive: bool = False,
+        as_dict: bool = False,
+        timeout: float | None = None,
+        _deadline: float | None = None,
+    ) -> list[str] | dict[str, NotebookPage]:
+        """Lists pages within this container.
+
+        :param recursive: If True, includes pages from all subdirectories.
+                          Recursive entries are keyed/named with their full relative path.
+        :type recursive: bool
+        :param as_dict: If True, returns a dict mapping names to page objects.
+                        If False, returns a list of names.
+        :type as_dict: bool
+        :param timeout: Maximum seconds allowed for recursive traversal.
+                        Defaults to 10 when recursive is True, ignored otherwise.
+        :type timeout: float or None
+        :returns: A list of page names or a dict of ``{name: NotebookPage}``.
+        :rtype: list[str] or dict[str, NotebookPage]
+        :raises TimeoutError: If the recursive traversal exceeds the timeout.
+        """
+        if recursive and _deadline is None:
+            _deadline = monotonic() + (timeout if timeout is not None else 10)
+
+        self._ensure_populated()
+
+        results: dict[str, NotebookPage] = {}
+
+        for child in self.children:
+            if not child.is_dir():
+                results[child.name] = child  # type: ignore[assignment]
+            elif recursive and isinstance(child, AbstractTreeContainer):
+                if _deadline is not None and monotonic() > _deadline:
+                    raise TimeoutError(
+                        "list_pages recursive traversal timed out"
+                    )
+                for sub_name, sub_page in child.list_pages(
+                    recursive=True, as_dict=True, _deadline=_deadline
+                ).items():
+                    results[f"{child.name}/{sub_name}"] = sub_page
+
+        if as_dict:
+            return results
+        return list(results.keys())
 
     def create_page(self, name: str) -> NotebookPage:
         """Creates a new page within this container.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -558,3 +558,59 @@ def test_tree_traversal(notebook: LA.Notebook, notebook_tree: LA.NotebookDirecto
     k = list(k.values())[0]
     assert isinstance(k, LA.NotebookDirectory)
     assert len(k) == 0
+
+
+def test_list_directories(notebook_tree: LA.Notebook):
+    dirs = notebook_tree.list_directories()
+    assert dirs == ["Test Folder A", "Test Folder B"]
+
+
+def test_list_directories_as_dict(notebook_tree: LA.Notebook):
+    dirs = notebook_tree.list_directories(as_dict=True)
+    assert set(dirs.keys()) == {"Test Folder A", "Test Folder B"}
+    assert isinstance(dirs["Test Folder A"], LA.NotebookDirectory)
+
+
+def test_list_directories_recursive(notebook_tree: LA.Notebook):
+    dirs = notebook_tree.list_directories(recursive=True)
+    assert "Test Folder A" in dirs
+    assert "Test Folder B" in dirs
+    assert "Test Folder B/Dir2 Subfolder A" in dirs
+    assert "Test Folder B/Dir2 Subfolder B" in dirs
+    assert "Test Folder B/Dir2 Subfolder B/Dir2 Subfolder B Subfolder" in dirs
+    assert len(dirs) == 5
+
+
+def test_list_directories_recursive_as_dict(notebook_tree: LA.Notebook):
+    dirs = notebook_tree.list_directories(recursive=True, as_dict=True)
+    assert len(dirs) == 5
+    assert isinstance(
+        dirs["Test Folder B/Dir2 Subfolder B/Dir2 Subfolder B Subfolder"],
+        LA.NotebookDirectory,
+    )
+
+
+def test_list_pages(notebook_tree: LA.Notebook):
+    pages = notebook_tree.list_pages()
+    assert pages == ["Test Page 1"]
+
+
+def test_list_pages_as_dict(notebook_tree: LA.Notebook):
+    pages = notebook_tree.list_pages(as_dict=True)
+    assert set(pages.keys()) == {"Test Page 1"}
+    assert isinstance(pages["Test Page 1"], LA.NotebookPage)
+
+
+def test_list_pages_recursive(notebook_tree: LA.Notebook):
+    pages = notebook_tree.list_pages(recursive=True)
+    assert "Test Page 1" in pages
+    assert "Test Folder A/Dir1 Test Page A" in pages
+    assert "Test Folder A/Dir1 Test Page B" in pages
+    assert "Test Folder B/Dir2 Test Page" in pages
+    assert len(pages) == 4
+
+
+def test_list_pages_recursive_as_dict(notebook_tree: LA.Notebook):
+    pages = notebook_tree.list_pages(recursive=True, as_dict=True)
+    assert len(pages) == 4
+    assert isinstance(pages["Test Folder A/Dir1 Test Page A"], LA.NotebookPage)


### PR DESCRIPTION
## Summary
- Added `list_directories()` and `list_pages()` methods to `AbstractTreeContainer`
- Returns names by default; pass `as_dict=True` to get `{name: object}` mappings
- Supports `recursive=True` for full subtree traversal (uses slash-separated relative paths)
- 8 new unit tests covering all combinations of options

Closes #7

## Test plan
- [x] `test_list_directories` — non-recursive, names only
- [x] `test_list_directories_as_dict` — non-recursive, dict
- [x] `test_list_directories_recursive` — recursive, names only
- [x] `test_list_directories_recursive_as_dict` — recursive, dict
- [x] `test_list_pages` — non-recursive, names only
- [x] `test_list_pages_as_dict` — non-recursive, dict
- [x] `test_list_pages_recursive` — recursive, names only
- [x] `test_list_pages_recursive_as_dict` — recursive, dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)