### PR TITLE
Warn when builtin browser detection support is unavailable

### DIFF
--- a/src/labapi/browser.py
+++ b/src/labapi/browser.py
@@ -10,9 +10,12 @@ opened manually by the user.
 The detected browser is exposed via the `default_browser` module-level variable.
 """
 
-try:
-    from os import getenv
+from os import getenv
 
+browser_warning: str | None = None
+raw_env_browser = getenv("LA_AUTH_BROWSER", "").strip().lower()
+
+try:
     import installed_browsers  # pyright: ignore[reportMissingTypeStubs]
 
     browsers = [
@@ -25,8 +28,6 @@ try:
         )
     ]
     raw_default_browser = installed_browsers.what_is_the_default_browser()
-    raw_env_browser = getenv("LA_AUTH_BROWSER", "").strip().lower()
-
     default_browser = "terminal"
 
     browser_choices = ["chrome", "firefox", "edge"]  # priority in order of order
@@ -57,3 +58,10 @@ try:
                         break
 except ImportError:
     default_browser = "terminal"
+    if raw_env_browser != "terminal":
+        browser_warning = (
+            "Automatic browser detection requires the optional builtin-auth "
+            "dependencies. Install them with "
+            "\"uv add labapi --optional builtin-auth\" or "
+            "\"pip install 'labapi[builtin-auth]'\"."
+        )

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -26,7 +26,7 @@ from requests import Response, Session
 from requests import codes as status_codes
 from requests.adapters import HTTPAdapter
 
-from .browser import default_browser
+from .browser import browser_warning, default_browser
 from .exceptions import ApiError, AuthenticationError
 from .user import User
 from .util import NotebookInit, extract_etree, to_bool
@@ -425,6 +425,8 @@ class Client:
                     driver = webdriver.Edge(options=options)
                     print("Opening Edge for authentication...")
                 case "terminal":
+                    if browser_warning:
+                        print(f"WARNING: {browser_warning}")
                     print("Open authentication URL in your browser:")
                     print(auth_url)
                 case _:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -88,3 +88,17 @@ def test_browser_detection_import_error():
         import labapi.browser
 
         assert labapi.browser.default_browser == "terminal"
+        assert labapi.browser.browser_warning is not None
+        assert "builtin-auth" in labapi.browser.browser_warning
+
+
+def test_browser_detection_import_error_terminal_env():
+    """Test explicit terminal mode does not warn about missing browser extras."""
+    with patch.dict("sys.modules", {"installed_browsers": None}):
+        with patch("os.getenv", return_value="terminal"):
+            if "labapi.browser" in sys.modules:
+                del sys.modules["labapi.browser"]
+            import labapi.browser
+
+            assert labapi.browser.default_browser == "terminal"
+            assert labapi.browser.browser_warning is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from os import getenv
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from requests import Response
@@ -121,6 +121,26 @@ class TestClientUnit:
         # redirect_uri is URL-encoded in the query string
         assert "redirect_uri=http%3A%2F%2Flocalhost%3A8089%2F" in auth_url
         assert "akid=test_akid" in auth_url
+
+    def test_default_authenticate_terminal_warns_when_builtin_auth_missing(self):
+        """Test terminal auth prints guidance when browser extras are unavailable."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+
+        with (
+            patch("labapi.client.default_browser", "terminal"),
+            patch(
+                "labapi.client.browser_warning",
+                "Install labapi builtin-auth support.",
+            ),
+            patch.object(client, "collect_auth_response", return_value="sentinel"),
+            patch("builtins.print") as mock_print,
+        ):
+            result = client.default_authenticate()
+
+        assert result == "sentinel"
+        mock_print.assert_any_call(
+            "WARNING: Install labapi builtin-auth support."
+        )
 
     def test_client_handle_request_status_success(self):
         """Test Client._handle_request_status with successful response."""


### PR DESCRIPTION
## Summary
- surface a specific warning when automatic browser detection falls back because the optional builtin-auth dependencies are not installed
- print that guidance during terminal-based default authentication
- add tests for the warning behavior and explicit terminal mode

## Testing
- uv run pytest tests/test_browser.py tests/test_client.py -p no:cacheprovider

Closes #14