### PR TITLE
Add Client.close() and context-manager support

### DIFF
--- a/docs/source/guide/auth.rst
+++ b/docs/source/guide/auth.rst
@@ -25,8 +25,12 @@ This method prompts the user to activate a link that will bring them to the LabA
 
     from labapi import Client
 
-    client = Client()
-    user = client.default_authenticate()
+    with Client() as client:
+        user = client.default_authenticate()
+
+Closing the client releases its underlying HTTP session. Any ``User`` objects
+created from that client should be treated as no longer valid for further API
+calls after the client has been closed.
 
 
 ``labapi`` provides two primary methods for authenticating users with LabArchives: an interactive browser-based flow and a manual flow that can be integrated into server-based applications.
@@ -75,4 +79,3 @@ Example Flask App
 
     if __name__ == "__main__":
         app.run(port=8080)
-

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -16,7 +16,7 @@ from io import BufferedIOBase
 from operator import itemgetter
 from os import getenv
 from socketserver import TCPServer
-from typing import Any, Generator, Mapping, Sequence, override
+from typing import Any, Generator, Mapping, Self, Sequence, override
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from cryptography.hazmat.primitives.hashes import SHA512
@@ -137,8 +137,33 @@ class Client:
             bytes(akpass, "utf8") if isinstance(akpass, str) else akpass, SHA512()
         )
         self.session = Session()
+        self._closed = False
         if not strict_cert:
             self.session.mount("https://", _313HTTPAdapter())
+
+    def close(self) -> None:
+        """Closes the underlying requests session.
+
+        Once closed, this client should not be used for further API requests.
+        Any :class:`~labapi.user.User` objects derived from this client should
+        also be treated as no longer usable for API calls.
+        """
+        if not self._closed:
+            self.session.close()
+            self._closed = True
+
+    def __enter__(self) -> Self:
+        """Returns this client for use as a context manager."""
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        """Closes the client session when exiting a context-manager block."""
+        self.close()
+
+    def _ensure_open(self) -> None:
+        """Raises if the client has already been closed."""
+        if self._closed:
+            raise RuntimeError("Client session is closed")
 
     def generate_auth_url(self, redirect_url: str) -> str:
         """
@@ -250,6 +275,7 @@ class Client:
         :returns: The full requests.Response object after the stream has been consumed.
         :raises RuntimeError: If the API request fails.
         """
+        self._ensure_open()
         with self.session.get(
             self.construct_url(api_method_uri, query=kwargs), stream=True
         ) as request:
@@ -280,6 +306,7 @@ class Client:
         :returns: The full requests.Response object after the stream has been consumed.
         :raises RuntimeError: If the API request fails.
         """
+        self._ensure_open()
         with self.session.post(
             self.construct_url(api_method_uri, query=kwargs), data=body, stream=True
         ) as request:
@@ -306,6 +333,7 @@ class Client:
         :returns: The requests.Response object containing the API response.
         :raises RuntimeError: If the API request fails.
         """
+        self._ensure_open()
         request = self.session.get(self.construct_url(api_method_uri, query=kwargs))
         Client._handle_request_status(request)
 
@@ -331,6 +359,7 @@ class Client:
         :returns: The requests.Response object containing the API response.
         :raises RuntimeError: If the API request fails.
         """
+        self._ensure_open()
         request = self.session.post(
             self.construct_url(api_method_uri, query=kwargs), data=body
         )
@@ -400,6 +429,7 @@ class Client:
         :raises ImportError: If selenium is not installed.
         :raises RuntimeError: If authentication fails.
         """
+        self._ensure_open()
         auth_url = self.generate_auth_url("http://localhost:8089/")
 
         driver = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -129,6 +129,37 @@ class TestClientUnit:
 
         Client._handle_request_status(response)
 
+    def test_client_close_closes_session(self):
+        """Test Client.close closes the underlying requests session."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.close = Mock()
+
+        client.close()
+
+        client.session.close.assert_called_once_with()
+
+    def test_client_context_manager_closes_session(self):
+        """Test Client closes its session when used as a context manager."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.close = Mock()
+
+        with client as managed:
+            assert managed is client
+
+        client.session.close.assert_called_once_with()
+
+    def test_client_rejects_requests_after_close(self):
+        """Test closed clients reject further request calls."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.get = Mock()
+
+        client.close()
+
+        with pytest.raises(RuntimeError, match="Client session is closed"):
+            client.raw_api_get("users/get_info")
+
+        client.session.get.assert_not_called()
+
     def test_client_handle_request_status_failure(self):
         """Test Client._handle_request_status with failed response."""
         response = Mock(spec=Response)


### PR DESCRIPTION
## Summary
- add Client.close() plus with Client(...) support for explicit session lifecycle management
- reject further request calls after a client has been closed so the lifecycle contract is explicit
- document that users derived from a closed client should be treated as unusable for further API calls
- add focused unit tests for close and context-manager behavior

## Testing
- uv run pytest tests/test_client.py -p no:cacheprovider

Closes #82