### PR TITLE
Replace library runtime asserts with explicit exceptions

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -123,7 +123,11 @@ class Entries(Sequence["Entry[Any]"]):
         :raises RuntimeError: If the API call to create the entry fails.
         """
         if issubclass(cls, AttachmentEntry):
-            assert isinstance(data, Attachment)
+            if not isinstance(data, Attachment):
+                raise TypeError(
+                    f"{cls.__name__} requires Attachment data, got "
+                    f"{type(data).__name__}"
+                )
             entry_tree = self._user.api_post(
                 "entries/add_attachment",
                 data._backing,  # pyright: ignore[reportPrivateUsage, reportArgumentType]
@@ -139,7 +143,10 @@ class Entries(Sequence["Entry[Any]"]):
             entry = cls(eid, data.caption, self._user)
 
         else:
-            assert isinstance(data, str)
+            if not isinstance(data, str):
+                raise TypeError(
+                    f"{cls.__name__} requires str data, got {type(data).__name__}"
+                )
             entry_tree = self._user.api_post(
                 "entries/add_entry",
                 {"entry_data": data},

--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -312,7 +312,8 @@ class AbstractTreeNode(AbstractBaseTreeNode):
             )
         else:
             api_deleted_items = api_deleted_items[0]
-            assert isinstance(api_deleted_items, AbstractTreeContainer)
+            if not isinstance(api_deleted_items, AbstractTreeContainer):
+                raise TypeError('"API Deleted Items" must be a directory')
 
         self.name = (
             f"{self.name} - Deleted at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"

--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -302,18 +302,7 @@ class AbstractTreeNode(AbstractBaseTreeNode):
 
         :returns: The instance of the deleted node.
         """
-        api_deleted_items = self.root[Index.Name : "API Deleted Items"]
-
-        if len(api_deleted_items) == 0:
-            from .directory import NotebookDirectory
-
-            api_deleted_items = self.root.create(
-                NotebookDirectory, "API Deleted Items", if_exists=InsertBehavior.Retain
-            )
-        else:
-            api_deleted_items = api_deleted_items[0]
-            if not isinstance(api_deleted_items, AbstractTreeContainer):
-                raise TypeError('"API Deleted Items" must be a directory')
+        api_deleted_items = self.root.dir("API Deleted Items")
 
         self.name = (
             f"{self.name} - Deleted at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -79,6 +79,41 @@ class TestEntriesUnit:
         entry_ids = [entry.id for entry in entries]
         assert entry_ids == ["eid_1", "eid_2", "eid_3"]
 
+    def test_entries_create_attachment_requires_attachment_data(self):
+        """Test attachment entry creation rejects non-attachment payloads."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        mock_page.id = "test_page_id"
+        mock_page.root = Mock()
+        mock_page.root.id = "test_notebook_id"
+        entries = Entries([], mock_user, mock_page)
+
+        with pytest.raises(TypeError, match="AttachmentEntry requires Attachment"):
+            entries.create(AttachmentEntry, "not an attachment")
+
+        mock_user.api_post.assert_not_called()
+
+    def test_entries_create_text_requires_str_data(self):
+        """Test text entry creation rejects non-string payloads."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        mock_page.id = "test_page_id"
+        mock_page.root = Mock()
+        mock_page.root.id = "test_notebook_id"
+        entries = Entries([], mock_user, mock_page)
+
+        attachment = Attachment(
+            backing=BytesIO(b"File content"),
+            mime_type="text/plain",
+            filename="test.txt",
+            caption="Test file",
+        )
+
+        with pytest.raises(TypeError, match="TextEntry requires str data"):
+            entries.create(TextEntry, attachment)  # pyright: ignore[reportArgumentType]
+
+        mock_user.api_post.assert_not_called()
+
 
 class TestEntriesIntegration:
     """Integration tests with real objects and mocked API."""

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -144,6 +144,23 @@ class TestTreeMixinsIntegration:
         client.api_log  # update_node for name
         client.api_log  # update_node for move
 
+    def test_delete_requires_deleted_items_directory(self, notebook_tree: Notebook):
+        """Test delete rejects a non-directory API Deleted Items node."""
+        notebook_tree._children.append(  # pyright: ignore[reportPrivateUsage]
+            NotebookPage(
+                "deleted-page",
+                "API Deleted Items",
+                notebook_tree,
+                notebook_tree,
+                notebook_tree.user,
+            )
+        )
+
+        page = notebook_tree[Index.Id : "page-1"].as_page()
+
+        with pytest.raises(TypeError, match='"API Deleted Items" must be a directory'):
+            page.delete()
+
     def test_mapping_methods(self, notebook_tree: Notebook):
         """Test keys(), values(), and items() on a container."""
         keys = list(notebook_tree.keys())

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -144,23 +144,6 @@ class TestTreeMixinsIntegration:
         client.api_log  # update_node for name
         client.api_log  # update_node for move
 
-    def test_delete_requires_deleted_items_directory(self, notebook_tree: Notebook):
-        """Test delete rejects a non-directory API Deleted Items node."""
-        notebook_tree._children.append(  # pyright: ignore[reportPrivateUsage]
-            NotebookPage(
-                "deleted-page",
-                "API Deleted Items",
-                notebook_tree,
-                notebook_tree,
-                notebook_tree.user,
-            )
-        )
-
-        page = notebook_tree[Index.Id : "page-1"].as_page()
-
-        with pytest.raises(TypeError, match='"API Deleted Items" must be a directory'):
-            page.delete()
-
     def test_mapping_methods(self, notebook_tree: Notebook):
         """Test keys(), values(), and items() on a container."""
         keys = list(notebook_tree.keys())


### PR DESCRIPTION
## Summary
- replace entry-creation runtime asserts with TypeError so invalid caller input fails explicitly even under optimized Python
- reject a non-directory API Deleted Items node with a targeted TypeError during delete
- add focused tests locking in the new exception behavior

## Testing
- uv run pytest tests/entry/test_collection.py tests/tree/test_mixins.py -p no:cacheprovider

Closes #81