### PR TITLE
Start the auth callback listener before launching auth

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -401,46 +401,50 @@ class Client:
         :raises RuntimeError: If authentication fails.
         """
         auth_url = self.generate_auth_url("http://localhost:8089/")
+        httpd, auth_info = self._create_auth_listener()
 
         driver = None
         options = None
         try:
-            match default_browser:
-                case "chrome":
-                    import selenium.webdriver as webdriver
+            with httpd:
+                match default_browser:
+                    case "chrome":
+                        import selenium.webdriver as webdriver
 
-                    options = webdriver.ChromeOptions()
-                    driver = webdriver.Chrome(options=options)
-                    print("Opening Chrome for authentication...")
-                case "firefox":
-                    import selenium.webdriver as webdriver
+                        options = webdriver.ChromeOptions()
+                        driver = webdriver.Chrome(options=options)
+                        print("Opening Chrome for authentication...")
+                    case "firefox":
+                        import selenium.webdriver as webdriver
 
-                    options = webdriver.FirefoxOptions()
-                    driver = webdriver.Firefox(options=options)
-                    print("Opening Firefox for authentication...")
-                case "edge":
-                    import selenium.webdriver as webdriver
+                        options = webdriver.FirefoxOptions()
+                        driver = webdriver.Firefox(options=options)
+                        print("Opening Firefox for authentication...")
+                    case "edge":
+                        import selenium.webdriver as webdriver
 
-                    options = webdriver.EdgeOptions()
-                    driver = webdriver.Edge(options=options)
-                    print("Opening Edge for authentication...")
-                case "terminal":
-                    print("Open authentication URL in your browser:")
-                    print(auth_url)
-                case _:
+                        options = webdriver.EdgeOptions()
+                        driver = webdriver.Edge(options=options)
+                        print("Opening Edge for authentication...")
+                    case "terminal":
+                        print("Open authentication URL in your browser:")
+                        print(auth_url)
+                    case _:
+                        print(
+                            "WARNING: No compatible browser detected (chrome, firefox, edge), defaulting to terminal"
+                        )
+                        print("Open authentication URL in your browser:")
+                        print(auth_url)
+
+                if driver is not None:
+                    driver.get(auth_url)
                     print(
-                        "WARNING: No compatible browser detected (chrome, firefox, edge), defaulting to terminal"
+                        "Please complete the authentication in the opened browser window..."
                     )
-                    print("Open authentication URL in your browser:")
-                    print(auth_url)
 
-            if driver is not None:
-                driver.get(auth_url)
-                print(
-                    "Please complete the authentication in the opened browser window..."
-                )
+                httpd.handle_request()
 
-            return self.collect_auth_response()
+            return self._complete_auth_response(auth_info)
         except ImportError as e:
             raise ImportError(
                 "Selenium is required for automatic browser-based authentication. "
@@ -462,6 +466,15 @@ class Client:
         :returns: A :class:`~labapi.user.User` object representing the authenticated user session.
         :raises KeyError: If the authentication code or email is not received.
         """
+        httpd, auth_info = self._create_auth_listener()
+
+        with httpd:
+            httpd.handle_request()
+
+        return self._complete_auth_response(auth_info)
+
+    def _create_auth_listener(self) -> tuple[TCPServer, dict[str, str]]:
+        """Creates and binds the local callback server used by the auth flow."""
 
         auth_info: dict[str, str] = {}
 
@@ -490,9 +503,10 @@ class Client:
             def log_message(self, format: str, *args: Any) -> None:
                 pass
 
-        with TCPServer(("127.0.0.1", 8089), AuthRequestHandler) as httpd:
-            httpd.handle_request()
+        return TCPServer(("127.0.0.1", 8089), AuthRequestHandler), auth_info
 
+    def _complete_auth_response(self, auth_info: Mapping[str, str]) -> User:
+        """Validates the auth callback data and completes the login flow."""
         if "error" in auth_info:
             raise AuthenticationError(f"Authentication failed: {auth_info['error']}")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from os import getenv
-from unittest.mock import Mock
+from types import ModuleType
+from unittest.mock import Mock, patch
 
 import pytest
 from requests import Response
@@ -165,6 +166,89 @@ class TestClientUnit:
         client = Client()
         assert client._base_url is not None
         assert client._akid is not None
+
+    def test_default_authenticate_binds_listener_before_terminal_prompt(self):
+        """Test terminal auth binds the callback listener before printing the URL."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        events: list[str] = []
+
+        class FakeServer:
+            def __enter__(self):
+                events.append("enter")
+                return self
+
+            def __exit__(self, *_args):
+                events.append("exit")
+
+            def handle_request(self):
+                events.append("handle_request")
+
+        def create_listener():
+            events.append("listener")
+            return FakeServer(), {}
+
+        def record_print(*_args, **_kwargs):
+            events.append("print")
+
+        with (
+            patch.object(client, "_create_auth_listener", side_effect=create_listener),
+            patch.object(client, "_complete_auth_response", return_value="sentinel"),
+            patch("labapi.client.default_browser", "terminal"),
+            patch("builtins.print", side_effect=record_print),
+        ):
+            result = client.default_authenticate()
+
+        assert result == "sentinel"
+        assert events.index("listener") < events.index("print")
+
+    def test_default_authenticate_binds_listener_before_opening_browser(self):
+        """Test browser auth binds the callback listener before opening the browser."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        events: list[str] = []
+
+        class FakeServer:
+            def __enter__(self):
+                events.append("enter")
+                return self
+
+            def __exit__(self, *_args):
+                events.append("exit")
+
+            def handle_request(self):
+                events.append("handle_request")
+
+        class FakeDriver:
+            def get(self, _url: str):
+                events.append("get")
+
+            def quit(self):
+                events.append("quit")
+
+        webdriver = ModuleType("selenium.webdriver")
+        webdriver.ChromeOptions = lambda: object()  # type: ignore[attr-defined]
+        webdriver.Chrome = lambda options=None: FakeDriver()  # type: ignore[attr-defined]
+
+        selenium = ModuleType("selenium")
+        selenium.webdriver = webdriver  # type: ignore[attr-defined]
+
+        def create_listener():
+            events.append("listener")
+            return FakeServer(), {}
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"selenium": selenium, "selenium.webdriver": webdriver},
+            ),
+            patch.object(client, "_create_auth_listener", side_effect=create_listener),
+            patch.object(client, "_complete_auth_response", return_value="sentinel"),
+            patch("labapi.client.default_browser", "chrome"),
+            patch("builtins.print"),
+        ):
+            result = client.default_authenticate()
+
+        assert result == "sentinel"
+        assert events.index("listener") < events.index("get")
 
 
 class TestClientIntegration:


### PR DESCRIPTION
## Summary
- bind the local auth callback server before opening a browser or printing the auth URL
- reuse the same listener/completion path from both default_authenticate() and collect_auth_response()
- add focused tests covering listener-before-terminal and listener-before-browser ordering

## Testing
- uv run pytest tests/test_client.py -p no:cacheprovider

Closes #83