### PR TITLE
Add direct unit coverage for Client request and streaming paths

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,13 +4,28 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from os import getenv
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
+from lxml.etree import XMLSyntaxError
 from requests import Response
 
 from labapi import Client, User
-from labapi.exceptions import ApiError
+from labapi.exceptions import ApiError, AuthenticationError
+
+
+def make_response(
+    status_code: int,
+    body: str,
+    url: str = "https://api.test.com/endpoint",
+) -> Response:
+    """Build a concrete requests.Response object for unit tests."""
+    response = Response()
+    response.status_code = status_code
+    response.url = url
+    response._content = body.encode("utf-8")
+    response.encoding = "utf-8"
+    return response
 
 
 class TestClientUnit:
@@ -138,6 +153,173 @@ class TestClientUnit:
 
         with pytest.raises(ApiError, match="API request failed with status code 404"):
             Client._handle_request_status(response)
+
+    def test_raw_api_get_returns_response(self):
+        """Test raw_api_get returns the raw response and calls session.get directly."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = make_response(200, "<users><id>123</id></users>")
+        client.session.get = Mock(return_value=response)
+
+        result = client.raw_api_get("users/get_info", uid="123")
+
+        assert result is response
+        called_url = client.session.get.call_args.args[0]
+        assert "users/get_info" in called_url
+        assert "uid=123" in called_url
+
+    def test_raw_api_post_returns_response(self):
+        """Test raw_api_post returns the raw response and passes the request body."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = make_response(200, "<entries><entry><eid>1</eid></entry></entries>")
+        client.session.post = Mock(return_value=response)
+        body = {"entry_data": "<p>Hello</p>"}
+
+        result = client.raw_api_post("entries/add_entry", body, pid="123")
+
+        assert result is response
+        called_url = client.session.post.call_args.args[0]
+        assert "entries/add_entry" in called_url
+        assert client.session.post.call_args.kwargs["data"] == body
+
+    def test_raw_api_get_raises_api_error_from_xml_error_body(self):
+        """Test raw_api_get surfaces LabArchives XML error payloads."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.get = Mock(
+            return_value=make_response(
+                500,
+                (
+                    "<error>"
+                    "<error-code>4999</error-code>"
+                    "<error-description>Unknown Error</error-description>"
+                    "</error>"
+                ),
+            )
+        )
+
+        with pytest.raises(ApiError, match=r"\[4999\] Unknown Error"):
+            client.raw_api_get("users/get_info")
+
+    def test_raw_api_get_raises_authentication_error_for_auth_failures(self):
+        """Test raw_api_get maps auth-related XML errors to AuthenticationError."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.get = Mock(
+            return_value=make_response(
+                401,
+                (
+                    "<error>"
+                    "<error-code>4533</error-code>"
+                    "<error-description>session timed out</error-description>"
+                    "</error>"
+                ),
+            )
+        )
+
+        with pytest.raises(AuthenticationError, match=r"\[4533\] session timed out"):
+            client.raw_api_get("users/get_info")
+
+    def test_api_get_parses_xml_response(self):
+        """Test api_get parses successful XML responses into Elements."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.get = Mock(
+            return_value=make_response(200, "<users><id>123</id></users>")
+        )
+
+        tree = client.api_get("users/get_info")
+
+        assert tree.tag == "users"
+        assert tree.findtext("./id") == "123"
+
+    def test_api_get_raises_on_malformed_xml(self):
+        """Test api_get propagates XML parse failures for malformed responses."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.get = Mock(return_value=make_response(200, "<users>"))
+
+        with pytest.raises(XMLSyntaxError):
+            client.api_get("users/get_info")
+
+    def test_api_post_parses_xml_response(self):
+        """Test api_post parses successful XML responses into Elements."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.post = Mock(
+            return_value=make_response(200, "<entry><eid>123</eid></entry>")
+        )
+
+        tree = client.api_post("entries/add_entry", {"entry_data": "<p>Hello</p>"})
+
+        assert tree.tag == "entry"
+        assert tree.findtext("./eid") == "123"
+
+    def test_api_post_raises_on_malformed_xml(self):
+        """Test api_post propagates XML parse failures for malformed responses."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client.session.post = Mock(return_value=make_response(200, "<entry>"))
+
+        with pytest.raises(XMLSyntaxError):
+            client.api_post("entries/add_entry", {"entry_data": "<p>Hello</p>"})
+
+    def test_stream_api_get_yields_chunks_and_returns_response(self):
+        """Test stream_api_get yields streamed chunks and returns the response."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = MagicMock(spec=Response)
+        response.__enter__.return_value = response
+        response.__exit__.return_value = None
+        response.status_code = 200
+        response.iter_content.return_value = [b"chunk-1", b"chunk-2"]
+        client.session.get = Mock(return_value=response)
+
+        stream = client.stream_api_get("attachments/download", eid="123")
+        chunks: list[bytes] = []
+
+        while True:
+            try:
+                chunks.append(next(stream))
+            except StopIteration as stop:
+                returned_response = stop.value
+                break
+
+        assert chunks == [b"chunk-1", b"chunk-2"]
+        assert returned_response is response
+
+    def test_stream_api_get_raises_api_error_before_yielding_chunks(self):
+        """Test stream_api_get raises before yielding when the response is not OK."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = MagicMock(spec=Response)
+        response.__enter__.return_value = response
+        response.__exit__.return_value = None
+        response.status_code = 404
+        response.url = "https://api.test.com/api/attachments/download"
+        response.text = "Not Found"
+        client.session.get = Mock(return_value=response)
+
+        with pytest.raises(ApiError, match="API request failed with status code 404"):
+            next(client.stream_api_get("attachments/download", eid="123"))
+
+        response.iter_content.assert_not_called()
+
+    def test_stream_api_post_yields_chunks_and_returns_response(self):
+        """Test stream_api_post yields streamed chunks and returns the response."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = MagicMock(spec=Response)
+        response.__enter__.return_value = response
+        response.__exit__.return_value = None
+        response.status_code = 200
+        response.iter_content.return_value = [b"chunk-1", b"chunk-2"]
+        client.session.post = Mock(return_value=response)
+
+        stream = client.stream_api_post(
+            "attachments/upload", {"entry_data": "test"}, eid="123"
+        )
+        chunks: list[bytes] = []
+
+        while True:
+            try:
+                chunks.append(next(stream))
+            except StopIteration as stop:
+                returned_response = stop.value
+                break
+
+        assert chunks == [b"chunk-1", b"chunk-2"]
+        assert returned_response is response
 
     def test_client_initialization_with_params(self):
         """Test Client initialization stores parameters correctly."""


### PR DESCRIPTION
## Summary
- add direct unit tests for aw_api_get and aw_api_post with mocked equests.Session methods
- cover XML parsing success and malformed-XML failures for pi_get and pi_post
- cover streaming success and failure behavior for stream_api_get and stream_api_post
- verify XML auth and non-auth API errors propagate as the correct exception types

## Testing
- uv run pytest tests/test_client.py -p no:cacheprovider

Closes #92