### PR TITLE
Reject ambiguous duplicate leaf names in extract_etree

### DIFF
--- a/src/labapi/util/extract.py
+++ b/src/labapi/util/extract.py
@@ -86,6 +86,23 @@ def extract_etree(_etree: Element, format: EtreeExtractorDict) -> dict[str, Any]
                         or if a callable extractor fails to process a value.
     """
     flat = _flatten_dict(format)
+    leaf_paths: dict[str, list[str]] = {}
+
+    for key in flat:
+        leaf_paths.setdefault(key.split("/")[-1], []).append(key)
+
+    duplicates = {
+        leaf: paths for leaf, paths in leaf_paths.items() if len(paths) > 1
+    }
+    if duplicates:
+        duplicate_text = "; ".join(
+            f"{leaf}: {', '.join(paths)}"
+            for leaf, paths in sorted(duplicates.items())
+        )
+        raise ValueError(
+            "Ambiguous extractor format has duplicate leaf keys: "
+            f"{duplicate_text}"
+        )
 
     items: dict[str, Any] = {}
 

--- a/src/labapi/util/extract.py
+++ b/src/labapi/util/extract.py
@@ -86,13 +86,15 @@ def extract_etree(_etree: Element, format: EtreeExtractorDict) -> dict[str, Any]
                         or if a callable extractor fails to process a value.
     """
     flat = _flatten_dict(format)
-    leaf_paths: dict[str, list[str]] = {}
+    leaf_extractors: dict[str, list[tuple[str, Callable[[Any], Any]]]] = {}
 
-    for key in flat:
-        leaf_paths.setdefault(key.split("/")[-1], []).append(key)
+    for key, mapper in flat.items():
+        leaf_extractors.setdefault(key.split("/")[-1], []).append((key, mapper))
 
     duplicates = {
-        leaf: paths for leaf, paths in leaf_paths.items() if len(paths) > 1
+        leaf: [path for path, _ in extractors]
+        for leaf, extractors in leaf_extractors.items()
+        if len(extractors) > 1
     }
     if duplicates:
         duplicate_text = "; ".join(
@@ -106,7 +108,8 @@ def extract_etree(_etree: Element, format: EtreeExtractorDict) -> dict[str, Any]
 
     items: dict[str, Any] = {}
 
-    for key, mapper in flat.items():
+    for leaf, extractors in leaf_extractors.items():
+        key, mapper = extractors[0]
         value = _etree.findtext(f"./{key}")
 
         if (
@@ -115,7 +118,7 @@ def extract_etree(_etree: Element, format: EtreeExtractorDict) -> dict[str, Any]
             raise ValueError(f"Could not find value for './{key}'")
 
         try:
-            items[key.split("/")[-1]] = mapper(value)
+            items[leaf] = mapper(value)
         except ValueError as err:
             raise ValueError(
                 f"Could not map value {value} with {mapper.__name__} for './{key}'"

--- a/tests/util/test_extract.py
+++ b/tests/util/test_extract.py
@@ -217,6 +217,31 @@ def test_extract_etree_mapper_fails_raises():
         extract_etree(element, format_dict)
 
 
+def test_extract_etree_rejects_duplicate_leaf_names():
+    """Test extract_etree rejects ambiguous nested formats with duplicate leaves."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <root>
+        <a>
+            <id>first</id>
+        </a>
+        <b>
+            <id>second</id>
+        </b>
+    </root>
+    """
+    element = etree.fromstring(bytes(xml, encoding="utf-8"))
+    format_dict: EtreeExtractorDict = {
+        "a": {"id": str},
+        "b": {"id": str},
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"Ambiguous extractor format has duplicate leaf keys: id: /a/id, /b/id",
+    ):
+        extract_etree(element, format_dict)
+
+
 def test_extract_etree_deeply_nested():
     """Test extract_etree with deeply nested structure."""
     xml = """<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- detect duplicate leaf-name collisions in nested extract_etree() formats before any XML lookup happens
- raise a targeted ValueError that lists the conflicting full paths instead of silently overwriting one result
- add focused tests for the duplicate-leaf case

## Testing
- uv run pytest tests/util/test_extract.py -p no:cacheprovider

Closes #80