### PR TITLE
Add walk_up support to NotebookPath.relative_to

### DIFF
--- a/src/labapi/util/path.py
+++ b/src/labapi/util/path.py
@@ -202,13 +202,32 @@ class NotebookPath(Sequence[str]):
         if not isinstance(other, NotebookPath):
             other = NotebookPath(other)
 
-        if not other._absolute and other._parent is None:
-            if self._absolute or self._parent is not None:
-                raise ValueError(
-                    "cannot compute a relative path from an anchored path "
-                    "against an unanchored relative base"
-                )
+        other_is_unanchored = not other._absolute and other._parent is None
+        self_is_anchored = self._absolute or self._parent is not None
 
+        if other_is_unanchored and self_is_anchored:
+            raise ValueError(
+                "cannot compute a relative path from an anchored path "
+                "against an unanchored relative base"
+            )
+
+        if self.is_relative_to(other):
+            if other_is_unanchored:
+                return NotebookPath(*self[len(other) :])
+
+            p_origin = other.resolve()
+            p_endpoint = self.resolve(other)
+            remaining = list(p_endpoint[len(p_origin) :])
+            return (
+                NotebookPath(*remaining, parent=p_origin)
+                if remaining
+                else NotebookPath("", parent=p_origin)
+            )
+
+        if not walk_up:
+            raise ValueError(f'Path "{self}" is outside of "{other}"')
+
+        if other_is_unanchored:
             p_origin = other
             p_endpoint = self
         else:
@@ -223,9 +242,6 @@ class NotebookPath(Sequence[str]):
             and p_origin[common_idx] == p_endpoint[common_idx]
         ):
             common_idx += 1
-
-        if not walk_up and common_idx < len(p_origin):
-            raise ValueError(f'Path "{self}" is outside of "{other}"')
 
         remaining = [".."] * (len(p_origin) - common_idx)
         remaining.extend(p_endpoint[common_idx:])

--- a/src/labapi/util/path.py
+++ b/src/labapi/util/path.py
@@ -179,7 +179,12 @@ class NotebookPath(Sequence[str]):
 
         return self.resolve().startswith(other.resolve())
 
-    def relative_to(self, other: NotebookPath | AbstractBaseTreeNode) -> NotebookPath:
+    def relative_to(
+        self,
+        other: NotebookPath | AbstractBaseTreeNode,
+        *,
+        walk_up: bool = False,
+    ) -> NotebookPath:
         """Return this path made relative to ``other``.
 
         The result is a new relative ``NotebookPath`` whose ``parent`` anchor
@@ -187,29 +192,51 @@ class NotebookPath(Sequence[str]):
         to an absolute path later.
 
         :param other: The ancestor path or tree node to relativise against.
+        :param walk_up: When ``True``, allow the returned path to include
+            ``..`` segments when ``other`` is not an ancestor of this path.
         :returns: A relative ``NotebookPath`` from ``other`` to this path.
-        :raises ValueError: If this path is not located inside ``other``.
+        :raises ValueError: If this path is not located inside ``other`` and
+            ``walk_up`` is ``False``, or if ``other`` is an unanchored relative
+            path while this path is anchored.
         """
-        # # TODO walk_up param
-
         if not isinstance(other, NotebookPath):
             other = NotebookPath(other)
 
-        if not self.is_relative_to(other):
+        if not other._absolute and other._parent is None:
+            if self._absolute or self._parent is not None:
+                raise ValueError(
+                    "cannot compute a relative path from an anchored path "
+                    "against an unanchored relative base"
+                )
+
+            p_origin = other
+            p_endpoint = self
+        else:
+            p_origin = other.resolve()
+            p_endpoint = self.resolve(other)
+
+        common_idx = 0
+        max_common = min(len(p_origin), len(p_endpoint))
+
+        while (
+            common_idx < max_common
+            and p_origin[common_idx] == p_endpoint[common_idx]
+        ):
+            common_idx += 1
+
+        if not walk_up and common_idx < len(p_origin):
             raise ValueError(f'Path "{self}" is outside of "{other}"')
 
-        if not other._absolute and other._parent is None:
-            return NotebookPath(*self[len(other) :])
+        remaining = [".."] * (len(p_origin) - common_idx)
+        remaining.extend(p_endpoint[common_idx:])
+        if p_origin._absolute or p_origin._parent is not None:
+            return (
+                NotebookPath(*remaining, parent=p_origin)
+                if remaining
+                else NotebookPath("", parent=p_origin)
+            )
 
-        p_origin = other.resolve()
-        p_endpoint = self.resolve(other)
-
-        remaining = list(p_endpoint[len(p_origin) :])
-        return (
-            NotebookPath(*remaining, parent=p_origin)
-            if remaining
-            else NotebookPath("", parent=p_origin)
-        )
+        return NotebookPath(*remaining) if remaining else NotebookPath("")
 
     @property
     def name(self) -> str:

--- a/tests/util/test_path.py
+++ b/tests/util/test_path.py
@@ -110,6 +110,38 @@ def test_notebook_path_relative_to_failure():
         path.relative_to(other)
 
 
+def test_notebook_path_relative_to_walk_up_absolute():
+    """Test relative_to can walk up between absolute paths when requested."""
+    path = NotebookPath("/Experiments/2024/Results")
+    other = NotebookPath("/Experiments/Archive")
+
+    rel = path.relative_to(other, walk_up=True)
+
+    assert rel.is_absolute() is False
+    assert str(rel) == "../2024/Results"
+    assert str(rel.resolve(other)) == "/Experiments/2024/Results"
+
+
+def test_notebook_path_relative_to_walk_up_relative():
+    """Test relative_to can walk up between unanchored relative paths."""
+    path = NotebookPath("a/b/c")
+    other = NotebookPath("a/d")
+
+    rel = path.relative_to(other, walk_up=True)
+
+    assert rel.is_absolute() is False
+    assert str(rel) == "../b/c"
+
+
+def test_notebook_path_relative_to_unanchored_base_rejects_anchored_path():
+    """Test anchored paths cannot relativize against unanchored relative bases."""
+    path = NotebookPath("/Experiments/2024")
+    other = NotebookPath("Experiments")
+
+    with pytest.raises(ValueError, match="unanchored relative base"):
+        path.relative_to(other, walk_up=True)
+
+
 def test_notebook_path_properties():
     """Test name, parts, and parent properties."""
     path = NotebookPath("/Experiments/2024/Results")


### PR DESCRIPTION
## Summary
- add a walk_up parameter to NotebookPath.relative_to() so it can return .. segments when the base path is not an ancestor
- preserve existing behavior by still raising when the path is outside the base unless walk_up=True
- add focused tests for absolute and relative walk-up cases plus anchored/unanchored error handling

## Testing
- uv run pytest tests/util/test_path.py -p no:cacheprovider

Closes #15