### PR TITLE
Move the pytest hook to pre-push and run it via uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,13 @@ repos:
   - repo: local
     hooks:
       - id: pytest-check
-        name: Run Pytest
-        entry: pytest
+        name: Run Pytest (pre-push)
+        entry: uv
+        args: [run, pytest, --no-cov]
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-push]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.14.11

--- a/docs/source/guide/contributing.rst
+++ b/docs/source/guide/contributing.rst
@@ -16,7 +16,7 @@ Install the package with its development dependencies using ``uv``:
 
     uv sync
     source .venv/bin/activate
-    pre-commit install
+    pre-commit install --hook-type pre-commit --hook-type pre-push
 
 Running Tests
 -------------
@@ -80,10 +80,11 @@ formatting.
 Pre-commit hooks
 ~~~~~~~~~~~~~~~~
 
-After running ``pre-commit install``, Ruff runs automatically on every commit:
+After running ``pre-commit install --hook-type pre-commit --hook-type pre-push``:
 
-* **ruff-check** — lints and auto-fixes safe issues (``--fix``)
-* **ruff-format** — enforces consistent formatting
+* **ruff-check** - lints and auto-fixes safe issues (``--fix``)
+* **ruff-format** - enforces consistent formatting
+* **pytest-check** - runs ``uv run pytest --no-cov`` on ``pre-push``
 
 You can run them manually at any time:
 
@@ -91,6 +92,7 @@ You can run them manually at any time:
 
     ruff check --fix .
     ruff format .
+    uv run pytest --no-cov
 
 Or check without making changes:
 
@@ -110,7 +112,7 @@ Key conventions:
 * **``from __future__ import annotations``** is present in every module,
   enabling postponed evaluation of annotations and allowing forward references
   without string literals.
-* **Generics** are used throughout the entry system — :class:`~labapi.entry.entries.base.Entry`
+* **Generics** are used throughout the entry system - :class:`~labapi.entry.entries.base.Entry`
   is parameterized by its data type (e.g., ``Entry[Attachment]``), so callers
   get concrete return types without casting.
 * **``TYPE_CHECKING`` guards** prevent circular imports while keeping type
@@ -121,4 +123,4 @@ Key conventions:
   types produced by different index kinds.
 
 The project targets Python 3.12+ and uses modern syntax where it improves
-clarity — ``type`` aliases, ``match`` statements, and ``Self``.
+clarity - ``type`` aliases, ``match`` statements, and ``Self``.


### PR DESCRIPTION
## Summary
- route the local pytest hook through uv run pytest --no-cov instead of invoking pytest directly from the ambient environment
- move that hook to pre-push so full test runs are not forced on every commit
- update the contributor guide to match the actual hook installation and behavior

## Testing
- uv run pre-commit validate-config
- uv run pre-commit run pytest-check --all-files --hook-stage pre-push

Closes #91