### PR TITLE
Add an explicit integration-test selection boundary

### DIFF
--- a/docs/source/guide/contributing.rst
+++ b/docs/source/guide/contributing.rst
@@ -27,7 +27,8 @@ Unit tests
 ~~~~~~~~~~
 
 Unit tests use a ``MockClient`` that replays pre-recorded API responses, so
-they run entirely offline:
+they run entirely offline. Plain ``pytest`` deselects integration tests by
+default:
 
 .. code-block:: bash
 
@@ -66,10 +67,13 @@ Run them explicitly:
 
 .. code-block:: bash
 
-    pytest tests/test_integration.py
+    pytest --integration tests/test_integration.py
 
-They are excluded from the default ``pytest`` run when credentials are absent
-(the fixture calls ``pytest.skip`` automatically).
+To run the full suite, including integration tests:
+
+.. code-block:: bash
+
+    pytest --integration
 
 Code Style
 ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser):
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="run tests marked as integration tests",
+    )
+
+
+def pytest_configure(config: pytest.Config):
+    config.addinivalue_line(
+        "markers", "integration: mark test as requiring live LabArchives access"
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if config.getoption("--integration"):
+        return
+
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+
+    for item in items:
+        if "integration" in item.keywords:
+            deselected.append(item)
+        else:
+            selected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,8 @@ import pytest
 import labapi as LA
 from labapi import Index
 
+pytestmark = pytest.mark.integration
+
 type AnyDict = Mapping[str, AnyDict | str | bool | int | float]
 try:
     from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- mark the integration module explicitly with an integration marker
- add a --integration pytest option and deselect integration tests by default so plain pytest stays on the fast unit-only path
- update the contributor guide with the explicit integration commands

## Testing
- uv run pytest tests/test_client.py -p no:cacheprovider -q
- uv run pytest tests/test_integration.py -p no:cacheprovider -q
- uv run pytest --integration tests/test_integration.py -p no:cacheprovider -q

Closes #90