### PR TITLE
Return snapshot views from container children

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -358,12 +358,13 @@ class AbstractTreeContainer(
 
     @property
     def children(self) -> Sequence[AbstractTreeNode]:
-        """A sequence of the direct children nodes within this container.
+        """A snapshot of the direct children nodes within this container.
 
-        :returns: A sequence of :class:`AbstractTreeNode` objects.
+        :returns: An immutable point-in-time sequence of
+            :class:`AbstractTreeNode` objects.
         """
         self._ensure_populated()
-        return self._children
+        return tuple(self._children)
 
     def _ensure_populated(self) -> None:
         """Ensures that the children of this container have been loaded from the API.

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -157,6 +157,31 @@ class TestTreeMixinsIntegration:
         items = dict(notebook_tree.items())
         assert items["Test Folder A"].id == "dir-1"
 
+    def test_children_returns_snapshot(self, client, notebook_tree: Notebook):
+        """Test children returns an immutable snapshot instead of a live list."""
+        snapshot = notebook_tree.children
+
+        assert isinstance(snapshot, tuple)
+
+        client.api_response = """
+        <tree-tools>
+            <node>
+                <tree-id>snapshot-page-id</tree-id>
+            </node>
+        </tree-tools>
+        """
+
+        notebook_tree.create(NotebookPage, "Snapshot Test Page")
+
+        api_call = client.api_log
+        assert api_call[0] == "tree_tools/insert_node"
+        assert api_call[1]["display_text"] == "Snapshot Test Page"
+
+        assert all(child.name != "Snapshot Test Page" for child in snapshot)
+        assert any(
+            child.name == "Snapshot Test Page" for child in notebook_tree.children
+        )
+
     def test_enumeration(self, notebook_tree: Notebook):
         """Test enumerate_all, enumerate_dirs, and enumerate_pages."""
         # Max depth 1 by default


### PR DESCRIPTION
## Summary
- change AbstractTreeContainer.children to return an immutable snapshot instead of the live backing list
- document that children is now a point-in-time view
- add a regression test proving an older snapshot does not change after a later mutation

## Testing
- uv run pytest tests/tree/test_mixins.py -p no:cacheprovider

Closes #21