### PR TITLE
Add a lightweight authenticated session check

### DIFF
--- a/src/labapi/user.py
+++ b/src/labapi/user.py
@@ -119,6 +119,19 @@ class User:
             self.api_get("users/max_file_size"), {"max-file-size": int}
         )["max-file-size"]
 
+    def check(self) -> bool:
+        """Performs a lightweight authenticated API call to verify the session.
+
+        This uses the ``users/max_file_size`` endpoint as a cheap probe and
+        returns ``True`` when the request succeeds. Authentication and API
+        failures are allowed to propagate so callers can distinguish them.
+
+        :returns: ``True`` when the authenticated session is valid.
+        :raises RuntimeError: If the API request fails.
+        """
+        self.api_get("users/max_file_size")
+        return True
+
     @property
     def notebooks(self) -> Notebooks:
         """Provides access to the user's notebooks.

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -56,6 +56,21 @@ class TestUserUnit:
         )
         assert result is mock_element
 
+    def test_user_check_uses_lightweight_probe(self):
+        """Test User.check uses users/max_file_size as its session probe."""
+        mock_client = Mock()
+        mock_element = etree.fromstring(
+            b"<users><max-file-size>104857600</max-file-size></users>"
+        )
+        mock_client.api_get.return_value = mock_element
+
+        user = User("user_789", "test@example.com", [], mock_client)
+
+        assert user.check() is True
+        mock_client.api_get.assert_called_once_with(
+            "users/max_file_size", uid="user_789"
+        )
+
 
 class TestUserIntegration:
     """Integration tests with real objects and mocked API."""
@@ -126,6 +141,20 @@ class TestUserIntegration:
         max_size = user.get_max_upload_size()
 
         assert max_size == 104857600
+
+        api_call = client.api_log
+        assert api_call[0] == "users/max_file_size"
+        assert api_call[1]["uid"] == "testid1"
+
+    def test_user_check(self, client, user: User):
+        """Test User.check succeeds via the lightweight probe endpoint."""
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <users>
+            <max-file-size type="integer">104857600</max-file-size>
+        </users>
+        """
+
+        assert user.check() is True
 
         api_call = client.api_log
         assert api_call[0] == "users/max_file_size"


### PR DESCRIPTION
## Summary
- add User.check() as a lightweight authenticated probe based on users/max_file_size
- keep the method simple: return True on success and let authentication/API failures propagate
- add focused unit and integration-style tests covering the new probe

## Testing
- uv run pytest tests/test_user.py -p no:cacheprovider

Closes #18