### PR TITLE
Add explicit client configuration validation

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -140,6 +140,24 @@ class Client:
         if not strict_cert:
             self.session.mount("https://", _313HTTPAdapter())
 
+    def validate_config(self) -> bool:
+        """Return whether this client has a usable local configuration.
+
+        This validation is local only and does not make any API calls. It
+        checks that the base URL is still well-formed and that the auth/signing
+        state required for later requests is present.
+
+        :returns: ``True`` when the client appears locally configured and
+            ready for authenticated API calls, otherwise ``False``.
+        """
+        parsed = urlsplit(self._base_url)
+        return bool(
+            parsed.scheme
+            and parsed.netloc
+            and self._akid
+            and getattr(self, "_hmac", None) is not None
+        )
+
     def generate_auth_url(self, redirect_url: str) -> str:
         """
         Generates a URL for authenticating with the LabArchives API.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -146,6 +146,26 @@ class TestClientUnit:
         assert client._base_url == "https://custom.api.com"
         assert client._akid == "my_akid"
 
+    def test_client_validate_config_returns_true_for_valid_client(self):
+        """Test validate_config returns True for a normally constructed client."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+
+        assert client.validate_config() is True
+
+    def test_client_validate_config_returns_false_for_invalid_base_url(self):
+        """Test validate_config returns False when the base URL is malformed."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client._base_url = "not-a-url"
+
+        assert client.validate_config() is False
+
+    def test_client_validate_config_returns_false_for_missing_signing_state(self):
+        """Test validate_config returns False when signing state is missing."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        client._hmac = None  # type: ignore[assignment]
+
+        assert client.validate_config() is False
+
     def test_client_initialization_from_env_vars(self, monkeypatch):
         """Test Client initialization reads from environment variables."""
         monkeypatch.setenv("ACCESS_KEYID", "test_akid")


### PR DESCRIPTION
## Summary
- add Client.validate_config() for explicit local-only configuration validation
- check the configured base URL plus signing state without making API calls
- add focused unit tests for valid and invalid client state

## Testing
- uv run pytest tests/test_client.py -p no:cacheprovider

Closes #19