### PR TITLE
Fix enumeration docs to use depth parameter

### DIFF
--- a/docs/source/guide/paths.rst
+++ b/docs/source/guide/paths.rst
@@ -71,18 +71,18 @@ This is useful for listing or searching the tree without fetching every node ind
     # e.g. ["Experiments", "Experiments/2024", "Protocols"]
 
     # Only directories
-    notebook.enumerate_dirs(max_depth=2)
+    notebook.enumerate_dirs(depth=2)
 
     # Only pages
-    notebook.enumerate_pages(max_depth=2)
+    notebook.enumerate_pages(depth=2)
 
-``max_depth`` defaults to ``1`` (immediate children only). To fetch the full tree you can increase
+``depth`` defaults to ``1`` (immediate children only). To fetch the full tree you can increase
 it, but be aware that this makes one API request per directory level visited.
 
 .. code-block:: python
 
     # Enumerate up to 3 levels deep
-    all_paths = notebook.enumerate_all(max_depth=3)
+    all_paths = notebook.enumerate_all(depth=3)
 
     for path in all_paths:
         node = notebook.traverse(path)
@@ -161,3 +161,4 @@ nodes or strings, combined with ``/``, and converted back to strings. It is used
 
     page_path.is_relative_to(folder)   # True if page is inside folder
     page_path.is_relative_to(notebook) # True (everything is inside the notebook)
+

--- a/docs/source/quick_start/navigating.rst
+++ b/docs/source/quick_start/navigating.rst
@@ -93,22 +93,22 @@ To discover what the contents of a directory are, ``labapi`` provides the follow
 Listing All Children
 ^^^^^^^^^^^^^^^^^^^^
 
-:meth:`~labapi.tree.mixins.AbstractTreeContainer.enumerate_all` returns relative path strings for all descendants up to ``max_depth`` (default is 1):
+:meth:`~labapi.tree.mixins.AbstractTreeContainer.enumerate_all` returns relative path strings for all descendants up to ``depth`` (default is 1):
 
 .. code-block:: python
 
    all_items = notebook.enumerate_all()
    # Returns: ['Experiments', 'Notes']
 
-   all_items = notebook.enumerate_all(max_depth=3)
+   all_items = notebook.enumerate_all(depth=3)
    # Returns: ['Experiments', 'Experiments/2024', 'Experiments/2024/Results', 'Experiments/Archive', 'Notes']
 
    experiments = notebook['Experiments']
-   experiment_items = experiments.enumerate_all(max_depth=2)
+   experiment_items = experiments.enumerate_all(depth=2)
    # Returns: ['2024', '2024/Results', 'Archive']
 
 .. note::
-   The ``max_depth`` parameter controls how many levels deep to traverse in the tree structure:
+   The ``depth`` parameter controls how many levels deep to traverse in the tree structure:
 
    Given this tree structure::
 
@@ -119,9 +119,9 @@ Listing All Children
       │   └── Archive
       └── Notes
 
-   - ``max_depth=1`` returns: ``['Experiments', 'Notes']``
-   - ``max_depth=2`` returns: ``['Experiments', 'Experiments/2024', 'Experiments/Archive', 'Notes']``
-   - ``max_depth=3`` returns: ``['Experiments', 'Experiments/2024', 'Experiments/2024/Results', 'Experiments/Archive', 'Notes']``
+   - ``depth=1`` returns: ``['Experiments', 'Notes']``
+   - ``depth=2`` returns: ``['Experiments', 'Experiments/2024', 'Experiments/Archive', 'Notes']``
+   - ``depth=3`` returns: ``['Experiments', 'Experiments/2024', 'Experiments/2024/Results', 'Experiments/Archive', 'Notes']``
 
 Listing Only Directories
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ Listing Only Directories
    directories = notebook.enumerate_dirs()
    # Returns: ['Experiments']
 
-   directories = notebook.enumerate_dirs(max_depth=2)
+   directories = notebook.enumerate_dirs(depth=2)
    # Returns: ['Experiments', 'Experiments/2024']
 
    experiments = notebook['Experiments']
@@ -150,11 +150,11 @@ Listing Only Pages
    pages = notebook.enumerate_pages()
    # Returns: ['Notes']
 
-   pages = notebook.enumerate_pages(max_depth=2)
+   pages = notebook.enumerate_pages(depth=2)
    # Returns: ['Experiments/Archive', 'Notes']
 
    experiments = notebook['Experiments']
-   experiment_pages = experiments.enumerate_pages(max_depth=2)
+   experiment_pages = experiments.enumerate_pages(depth=2)
    # Returns: ['Archive', '2024/Results']
 
 
@@ -211,3 +211,4 @@ This allows you to access directory-specific methods and attributes without your
         directory.create(NotebookPage, "New Page")
 
 If you call :meth:`~labapi.tree.mixins.AbstractBaseTreeNode.as_dir` on a node that is not a directory, it will raise a :class:`TypeError`.
+


### PR DESCRIPTION
## Summary
- replace invalid `max_depth=` examples with the implemented `depth=` keyword
- update the quick-start navigation guide and the deeper paths guide consistently
- keep the explanatory prose aligned with the actual method signatures

## Testing
- rg -n max_depth docs/source/quick_start/navigating.rst docs/source/guide/paths.rst

Closes #38