### PR TITLE
Clarify notebook and tree iteration docs

### DIFF
--- a/docs/source/guide/auth.rst
+++ b/docs/source/guide/auth.rst
@@ -69,9 +69,9 @@ Example Flask App
         # Log the user in and get the user object
         user = client.login(email, auth_code)
 
-        # Now you can use the user object to make API calls, or save the user object in a session
-        notebooks = user.notebooks
-        return f"Logged in as {user.id}. Notebooks: {[n.name for n in notebooks]}"
+        # Iterate over user.notebooks for names, or use values() for Notebook objects
+        notebook_names = list(user.notebooks)
+        return f"Logged in as {user.id}. Notebooks: {notebook_names}"
 
     if __name__ == "__main__":
         app.run(port=8080)

--- a/docs/source/guide/index_access.rst
+++ b/docs/source/guide/index_access.rst
@@ -16,6 +16,9 @@ This indexing method is supported by the following collection types:
 .. warning::
    This indexing method is **not** supported for page **``Entries``**. Page entries must be accessed by their integer index or via iteration.
 
+.. note::
+   Iterating over ``user.notebooks`` or a tree container yields names. Use ``values()`` to iterate over notebook or node objects, or ``items()`` to iterate over ``(name, object)`` pairs.
+
 Basic Access by Name
 --------------------
 

--- a/docs/source/quick_start/first_calls.rst
+++ b/docs/source/quick_start/first_calls.rst
@@ -117,9 +117,13 @@ Once you have a :class:`~labapi.user.User` object, you can access your notebooks
    # Get a notebook by name
    notebook = user.notebooks["My Notebook"]
 
-   # Or list all your notebooks
+   # Or list all your notebook names
    for notebook_name in user.notebooks:
        print(notebook_name)
+
+   # Use values() when you need Notebook objects instead of names
+   for notebook in user.notebooks.values():
+       print(notebook.name, notebook.id)
 
 
 


### PR DESCRIPTION
## Summary
- fix the auth guide example so it iterates over notebook names correctly
- show user.notebooks.values() when callers need Notebook objects instead of names
- document that notebook collections and tree containers iterate over names by default

## Testing
- rg -n notebook_names docs/source/guide/auth.rst
- rg -n user.notebooks.values docs/source/quick_start/first_calls.rst docs/source/guide/index_access.rst

Closes #72