### PR TITLE
Clarify Attachment.from_file upload docs

### DIFF
--- a/docs/source/guide/entries.rst
+++ b/docs/source/guide/entries.rst
@@ -107,15 +107,17 @@ To create an attachment entry, you first need to create an :class:`~labapi.entry
    # Upload as a new entry
    page.entries.create(AttachmentEntry, attachment)
 
-You can also create an attachment directly from a file on disk:
+You can also create an attachment from any readable binary stream with a ``name`` attribute, including a normal file on disk:
 
 .. code-block:: python
 
    from labapi import Attachment, AttachmentEntry
 
-   with open("data.csv", "rb+") as f:
+   with open("data.csv", "rb") as f:
        attachment = Attachment.from_file(f)
        page.entries.create(AttachmentEntry, attachment)
+
+:meth:`~labapi.entry.attachment.Attachment.from_file` copies the input into its own temporary buffer, so the source handle only needs to be readable. If your stream does not provide a ``name`` attribute, construct :class:`~labapi.entry.attachment.Attachment` manually instead.
 
 Working with JSON Data
 ----------------------
@@ -147,6 +149,6 @@ For attachments, setting the ``content`` property with a new :class:`~labapi.ent
 
 .. code-block:: python
 
-   with open("updated_data.csv", "rb+") as f:
+   with open("updated_data.csv", "rb") as f:
        new_attachment = Attachment.from_file(f)
        attachment_entry.content = new_attachment

--- a/docs/source/quick_start/uploading_files.rst
+++ b/docs/source/quick_start/uploading_files.rst
@@ -11,19 +11,19 @@ Uploading file attachments is a bit different than other entry types. Uploading 
 Creating an Attachment
 ----------------------
 
-The :class:`~labapi.entry.attachment.Attachment` class represents a file to be uploaded. You can create an attachment from a 
-file-like object (e.g., a file opened in binary mode).
+The :class:`~labapi.entry.attachment.Attachment` class represents a file to be uploaded. You can create an attachment from a
+readable binary file object or other binary stream that also provides a ``name`` attribute.
 
 .. code-block:: python
 
     from labapi import Attachment
 
-    with open("my_file.txt", "rb+") as f:
+    with open("my_file.txt", "rb") as f:
         attachment = Attachment.from_file(f)
 
 .. note::
-    Currently, the file must be opened in a read-writable mode (e.g., "rb+").
-    This is a limitation of the current implementation and will be addressed in a future update.
+    :meth:`~labapi.entry.attachment.Attachment.from_file` only needs a readable binary stream and a ``name`` attribute.
+    It copies the content into its own temporary buffer, so the source handle does not need to be writable.
 
 The :meth:`~labapi.entry.attachment.Attachment.from_file` method automatically guesses the MIME type from the file's name. If the MIME type cannot be determined, it 
 defaults to ``application/octet-stream``.


### PR DESCRIPTION
## Summary
- change Attachment.from_file examples from rb+ to rb
- document that the helper only needs a readable binary stream with a name attribute
- explain when callers should construct Attachment manually instead

## Testing
- reviewed docs/source/quick_start/uploading_files.rst
- reviewed docs/source/guide/entries.rst

Closes #51