### PR TITLE
Document refresh behavior after tree mutations

### DIFF
--- a/docs/source/guide/clearing_cache.rst
+++ b/docs/source/guide/clearing_cache.rst
@@ -51,6 +51,32 @@ Similarly, you can refresh directories and notebooks to reload their children:
     # Next access gets fresh data
     children = directory.children  # Re-fetches from API
 
+When You Usually Do Not Need Refresh
+-----------------------------------
+
+If you create, rename, move, or delete nodes through this client, the in-memory tree is updated immediately as part of the same operation. In those cases, you usually do not need to call ``refresh()`` just to observe your own change locally.
+
+This includes:
+
+* ``create()`` appending a new page or directory to the parent container
+* ``node.name = "..."`` updating the current object's name in memory after the API call
+* ``move_to()`` updating the node's parent and both containers' child lists
+* ``delete()`` renaming and moving the current node into ``API Deleted Items``
+
+.. code-block:: python
+
+    from labapi import NotebookDirectory, NotebookPage
+
+    archive = notebook.create(NotebookDirectory, "Archive")
+    page = notebook.create(NotebookPage, "Fresh Results")
+
+    print("Fresh Results" in list(notebook))
+
+    page.move_to(archive)
+    print(page.parent is archive)  # True without refresh()
+
+Use ``refresh()`` when you need to pick up changes made outside the current object graph, such as edits from another user, the web UI, or a separate API session.
+
 When to Refresh Data
 --------------------
 

--- a/docs/source/quick_start/creating_pages.rst
+++ b/docs/source/quick_start/creating_pages.rst
@@ -32,9 +32,9 @@ available on any :class:`~labapi.tree.notebook.Notebook` or
     subfolder = my_folder.create(NotebookDirectory, "2024 Results")
 
 .. note::
-    Tree mutation methods such as ``create()`` update the local object graph immediately.
-    If you just created a page or directory through this client, you can keep using the
-    returned object and parent container without calling ``refresh()`` first.
+    Tree mutation methods such as ``create()`` update the local cached objects
+    immediately. The created node is ready to use right away, and you can fetch
+    ``children`` again if you want a fresh child snapshot that includes it.
 
 Handling Existing Nodes
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/quick_start/creating_pages.rst
+++ b/docs/source/quick_start/creating_pages.rst
@@ -31,6 +31,11 @@ available on any :class:`~labapi.tree.notebook.Notebook` or
     # Create nested directories
     subfolder = my_folder.create(NotebookDirectory, "2024 Results")
 
+.. note::
+    Tree mutation methods such as ``create()`` update the local object graph immediately.
+    If you just created a page or directory through this client, you can keep using the
+    returned object and parent container without calling ``refresh()`` first.
+
 Handling Existing Nodes
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary
- explain that create, rename, move, and delete operations update the local tree immediately
- clarify that refresh is usually only needed for changes made outside the current object graph
- add a quick-start note so users do not add unnecessary refresh calls after creation

## Testing
- reviewed docs/source/guide/clearing_cache.rst
- reviewed docs/source/quick_start/creating_pages.rst

Closes #27