### PR TITLE
Add local-only node name validation helper

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -31,6 +31,7 @@ from labapi.util import (
     NotebookPath,
     extract_etree,
     to_bool,
+    validate_node_name,
 )
 
 if TYPE_CHECKING:
@@ -252,6 +253,7 @@ class AbstractTreeNode(AbstractBaseTreeNode):
 
         :param value: The new name for the node.
         """
+        validate_node_name(value)
         self.user.api_get(
             "tree_tools/update_node",
             nbid=self.root.id,
@@ -634,7 +636,10 @@ class AbstractTreeContainer(
 
         if len(path) == 0:
             raise ValueError("Path cannot be empty")
-        elif len(path) == 1:
+
+        validate_node_name(path.name)
+
+        if len(path) == 1:
             nodes = [n for n in self[Index.Name : path.name] if isinstance(n, cls)]
 
             if nodes:

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, override
 
-from labapi.util import extract_etree, to_bool
+from labapi.util import extract_etree, to_bool, validate_node_name
 
 from .mixins import AbstractTreeContainer, HasNameMixin
 
@@ -59,6 +59,7 @@ class Notebook(AbstractTreeContainer):
 
         :param value: The new name for the notebook.
         """
+        validate_node_name(value)
         self.user.api_get("notebooks/modify_notebook_info", nbid=self.id, name=value)
 
         self._name = value

--- a/src/labapi/util/__init__.py
+++ b/src/labapi/util/__init__.py
@@ -2,7 +2,8 @@
 
 This package provides various utility functions and classes used throughout
 the LabArchives API client, including XML extraction, type conversions,
-indexing mechanisms, and data structures for notebook initialization.
+indexing mechanisms, validation helpers, and data structures for notebook
+initialization.
 """
 
 from .extract import extract_etree, to_bool
@@ -16,6 +17,7 @@ from .types import (
     NameIndex,
     NotebookInit,
 )
+from .validation import validate_node_name
 
 #: All known LabArchives entry part types.
 ALL_PART_TYPES = (
@@ -39,6 +41,7 @@ __all__ = [
     "NameIndex",
     "NotebookInit",
     "NotebookPath",
+    "validate_node_name",
     "ALL_PART_TYPES",
     "extract_etree",
     "to_bool",

--- a/src/labapi/util/validation.py
+++ b/src/labapi/util/validation.py
@@ -1,0 +1,24 @@
+"""Validation helpers for local LabArchives naming semantics."""
+
+from __future__ import annotations
+
+
+def validate_node_name(name: str) -> None:
+    """Validate a single node name against local path semantics.
+
+    This helper only enforces client-side constraints implied by local path
+    handling. It does not attempt to mirror all server-side LabArchives naming
+    rules.
+
+    :param name: A single node name or path segment.
+    :raises ValueError: If the name is empty, whitespace-only, contains '/',
+        or equals '..'.
+    """
+    if name == "":
+        raise ValueError("Node name cannot be empty")
+    if name.strip() == "":
+        raise ValueError("Node name cannot be only whitespace")
+    if "/" in name:
+        raise ValueError('Node name cannot contain "/"')
+    if name == "..":
+        raise ValueError('Node name ".." is reserved for parent navigation')

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -9,7 +9,7 @@ from labapi.exceptions import NodeExistsError, TraversalError
 from labapi.tree.mixins import (
     AbstractTreeContainer,
 )
-from labapi.util import InsertBehavior
+from labapi.util import InsertBehavior, NotebookPath
 
 
 class TestTreeMixinsIntegration:
@@ -99,6 +99,18 @@ class TestTreeMixinsIntegration:
         api_call = client.api_log
         assert api_call[0] == "tree_tools/update_node"
         assert api_call[1]["display_text"] == "New Name"
+
+    def test_name_setter_rejects_invalid_name_without_api_request(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test updating a node name fails locally for invalid names."""
+        page = notebook_tree[Index.Id : "page-1"]
+        client.clear_log()
+
+        with pytest.raises(ValueError, match="reserved for parent navigation"):
+            page.name = ".."
+
+        assert client._api_logs == []
 
     def test_move_to(self, client, notebook_tree: Notebook):
         """Test moving a node to a new container."""
@@ -284,6 +296,25 @@ class TestTreeMixinsIntegration:
         """Test create rejects empty paths."""
         with pytest.raises(ValueError, match="Path cannot be empty"):
             notebook_tree.create(NotebookPage, "")
+
+    def test_create_rejects_invalid_leaf_name_without_api_request(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test create rejects invalid leaf names before making requests."""
+
+        class InvalidAbsolutePath:
+            def is_absolute(self) -> bool:
+                return True
+
+            def relative_to(self, _other) -> NotebookPath:
+                return NotebookPath("..", parent=NotebookPath(notebook_tree))
+
+        client.clear_log()
+
+        with pytest.raises(ValueError, match="reserved for parent navigation"):
+            notebook_tree.create(NotebookPage, InvalidAbsolutePath())
+
+        assert client._api_logs == []
 
     def test_create_nested_without_parents_raises(self, notebook_tree: Notebook):
         """Test create rejects nested paths when parents=False."""

--- a/tests/tree/test_notebook.py
+++ b/tests/tree/test_notebook.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pytest
+
 from labapi import Notebook
 from labapi.tree.collection import Notebooks
 from labapi.user import User
@@ -45,6 +47,17 @@ class TestNotebookIntegration:
         assert api_call[1]["nbid"] == "testnb1"
         assert api_call[1]["name"] == "Updated Notebook Name"
         assert notebook.name == "Updated Notebook Name"
+
+    def test_notebook_name_setter_rejects_invalid_name_without_api_request(
+        self, client, notebook: Notebook
+    ):
+        """Test Notebook.name rejects invalid names before any API call."""
+        client.clear_log()
+
+        with pytest.raises(ValueError, match='cannot contain "/"'):
+            notebook.name = "Bad/Name"
+
+        assert client._api_logs == []
 
     def test_notebook_inserts_from_bottom(self, client, notebook: Notebook):
         """Test Notebook.inserts_from_bottom lazy loads from API."""

--- a/tests/util/test_validation.py
+++ b/tests/util/test_validation.py
@@ -1,0 +1,35 @@
+"""Unit tests for node name validation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from labapi.util import validate_node_name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Experiment 1",
+        ".. copy",
+        "Folder.Name",
+    ],
+)
+def test_validate_node_name_accepts_valid_names(name: str):
+    """Test validate_node_name accepts names allowed by local path semantics."""
+    validate_node_name(name)
+
+
+@pytest.mark.parametrize(
+    ("name", "match"),
+    [
+        ("", "cannot be empty"),
+        ("   ", "cannot be only whitespace"),
+        ("Parent/Child", 'cannot contain "/"'),
+        ("..", "reserved for parent navigation"),
+    ],
+)
+def test_validate_node_name_rejects_invalid_names(name: str, match: str):
+    """Test validate_node_name rejects unsupported local path names."""
+    with pytest.raises(ValueError, match=match):
+        validate_node_name(name)


### PR DESCRIPTION
## Summary
- add `validate_node_name()` in `labapi.util` for the local path-semantic invalid cases called out in the issue thread
- use it in notebook/tree rename setters and in `AbstractTreeContainer.create()`
- add unit tests that assert invalid names fail locally and that no mocked API request is sent

## Notes
- this intentionally validates only empty, whitespace-only, `/`, and `..`
- it does not try to mirror undocumented LabArchives server-side naming rules

## Testing
- uv run pytest tests/util/test_validation.py tests/tree/test_mixins.py tests/tree/test_notebook.py -p no:cacheprovider

Closes #17