### PR TITLE
Stop using class names to decide create type

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -656,9 +656,9 @@ class AbstractTreeContainer(
                 nbid=self.root.id,
                 parent_tree_id=self.tree_id,
                 display_text=path.name,
-                is_folder="false"
-                if cls.__name__ == "NotebookPage"
-                else "true",  # TODO make more resilient
+                is_folder=(
+                    "true" if issubclass(cls, AbstractTreeContainer) else "false"
+                ),
             )
 
             tree_id = extract_etree(create_tree, {"node": {"tree-id": str}})["tree-id"]

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -224,6 +224,56 @@ class TestTreeMixinsIntegration:
         assert api_call[1]["display_text"] == "New Folder"
         assert api_call[1]["is_folder"] == "true"
 
+    def test_create_page_subclass_uses_page_semantics(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test creating a NotebookPage subclass still uses page semantics."""
+
+        class CustomNotebookPage(NotebookPage):
+            pass
+
+        client.api_response = """
+        <tree-tools>
+            <node>
+                <tree-id>custom-page-id</tree-id>
+            </node>
+        </tree-tools>
+        """
+
+        new_page = notebook_tree.create(CustomNotebookPage, "Subclass Page")
+
+        assert isinstance(new_page, CustomNotebookPage)
+
+        api_call = client.api_log
+        assert api_call[0] == "tree_tools/insert_node"
+        assert api_call[1]["display_text"] == "Subclass Page"
+        assert api_call[1]["is_folder"] == "false"
+
+    def test_create_directory_subclass_uses_directory_semantics(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test creating a NotebookDirectory subclass still uses directory semantics."""
+
+        class CustomNotebookDirectory(NotebookDirectory):
+            pass
+
+        client.api_response = """
+        <tree-tools>
+            <node>
+                <tree-id>custom-dir-id</tree-id>
+            </node>
+        </tree-tools>
+        """
+
+        new_dir = notebook_tree.create(CustomNotebookDirectory, "Subclass Folder")
+
+        assert isinstance(new_dir, CustomNotebookDirectory)
+
+        api_call = client.api_log
+        assert api_call[0] == "tree_tools/insert_node"
+        assert api_call[1]["display_text"] == "Subclass Folder"
+        assert api_call[1]["is_folder"] == "true"
+
     def test_create_nested_with_parents(self, client, notebook_tree: Notebook):
         """Test creating a nested page with parents=True."""
         # 1. Create parent folder "Parent"


### PR DESCRIPTION
## Summary
- replace the `cls.__name__ == NotebookPage` check in `AbstractTreeContainer.create()` with an explicit type-hierarchy check
- use `issubclass(cls, AbstractTreeContainer)` so page and directory subclasses keep the right `is_folder` API behavior
- add focused regression tests for both page and directory subclasses

## Notes
- this keeps the fix local to the existing type hierarchy instead of adding another metadata flag or an inline import
- the new tests cover the exact brittle case called out in the issue thread: behavior should not depend on the literal class name

## Testing
- uv run pytest tests/tree/test_mixins.py -p no:cacheprovider

Closes #43