### PR TITLE
Use basename semantics in Attachment.from_file

### DIFF
--- a/src/labapi/entry/attachment.py
+++ b/src/labapi/entry/attachment.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 from collections.abc import Buffer
 from mimetypes import guess_type
+from os.path import basename
 from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
@@ -35,18 +36,25 @@ class Attachment:
     """
 
     @staticmethod
-    def from_file(file: BufferedReader | BufferedRandom) -> Attachment:
+    def from_file(
+        file: BufferedReader | BufferedRandom,
+        filename: str | None = None,
+    ) -> Attachment:
         """Creates an Attachment from a file object by cloning its content.
 
         The content of the provided file is copied into a temporary buffer,
         making the Attachment independent of the original file's state.
-        The MIME type is automatically guessed from the file's name.
-        If the MIME type cannot be determined, it defaults to "application/octet-stream".
+        The MIME type is automatically guessed from the local file name or the
+        explicit remote filename override. If the MIME type cannot be determined,
+        it defaults to "application/octet-stream".
 
         :param file: The file object to create an attachment from. Must have a `name` attribute.
+        :param filename: Optional explicit remote filename to store in LabArchives.
+            Defaults to the basename of ``file.name``.
         :returns: A new Attachment object wrapping a clone of the file.
         """
-        mime_type = guess_type(file.name)[0] or "application/octet-stream"
+        remote_filename = filename or basename(file.name)
+        mime_type = guess_type(filename or file.name)[0] or "application/octet-stream"
 
         # Create a spooled temporary file as the new backing buffer.
         # It stays in memory until it reaches 4MB, then rolls over to disk.
@@ -57,7 +65,7 @@ class Attachment:
         return Attachment(
             backing,  # pyright: ignore[reportArgumentType]
             mime_type,
-            file.name,
+            remote_filename,
             caption=f"API-uploaded {mime_type} file.",
         )
 

--- a/tests/entry/test_attachment.py
+++ b/tests/entry/test_attachment.py
@@ -23,7 +23,7 @@ def test_attachment_from_file():
         with open(temp_file_path, "r+b") as file:
             attachment = Attachment.from_file(file)
 
-            assert attachment.filename == temp_file_path
+            assert attachment.filename == Path(temp_file_path).name
             assert attachment.mime_type == "text/plain"
             assert attachment.caption == "API-uploaded text/plain file."
     finally:
@@ -47,10 +47,28 @@ def test_attachment_from_file_buffered_reader():
 
             # Read content from attachment to verify cloning
             assert attachment.read() == b"Test content for BufferedReader"
-            assert attachment.filename == temp_file_path
+            assert attachment.filename == Path(temp_file_path).name
             assert attachment.mime_type == "text/plain"
     finally:
         # Clean up
+        Path(temp_file_path).unlink(missing_ok=True)
+
+
+def test_attachment_from_file_explicit_filename_override():
+    """Test creating Attachment with an explicit remote filename override."""
+    with tempfile.NamedTemporaryFile(
+        mode="w+b", suffix=".txt", delete=False
+    ) as temp_file:
+        temp_file.write(b"Test content")
+        temp_file_path = temp_file.name
+
+    try:
+        with open(temp_file_path, "rb") as file:
+            attachment = Attachment.from_file(file, filename="remote-name.txt")
+
+            assert attachment.filename == "remote-name.txt"
+            assert attachment.read() == b"Test content"
+    finally:
         Path(temp_file_path).unlink(missing_ok=True)
 
 


### PR DESCRIPTION
## Summary
- change `Attachment.from_file()` to default to the basename of `file.name` instead of the full local path
- add an optional `filename=` override so callers can still choose the remote attachment filename explicitly
- add focused tests for basename extraction and the explicit override path

## Notes
- this keeps the fix scoped to the remote filename semantics called out in the issue thread
- related upload-stream and docs follow-ups are left to their own issues instead of broadening this branch

## Testing
- uv run pytest tests/entry/test_attachment.py tests/entry/entries/test_attachment.py -p no:cacheprovider

Closes #37