### PR TITLE
Fix unreachable no-browser auth warning

### DIFF
--- a/src/labapi/browser.py
+++ b/src/labapi/browser.py
@@ -4,8 +4,8 @@ This module attempts to detect an installed web browser (Chrome, Firefox, or Edg
 to be used for OAuth-like authentication flows. It prioritizes a browser specified
 via the `LA_AUTH_BROWSER` environment variable, then the system's default browser,
 and finally any detected installed browser. If no compatible browser is found,
-it defaults to "terminal", indicating that the authentication URL should be
-opened manually by the user.
+it leaves detection unset so the authentication flow can warn and fall back to
+manual terminal mode.
 
 The detected browser is exposed via the `default_browser` module-level variable.
 """
@@ -27,11 +27,13 @@ try:
     raw_default_browser = installed_browsers.what_is_the_default_browser()
     raw_env_browser = getenv("LA_AUTH_BROWSER", "").strip().lower()
 
-    default_browser = "terminal"
+    default_browser: str | None = None
 
     browser_choices = ["chrome", "firefox", "edge"]  # priority in order of order
 
-    if raw_env_browser in ("chrome", "firefox", "edge", "terminal"):
+    if raw_env_browser == "terminal":
+        default_browser = "terminal"
+    elif raw_env_browser in browser_choices:
         if installed_browsers.do_i_have_installed(raw_env_browser):
             default_browser = raw_env_browser
     else:
@@ -43,11 +45,7 @@ try:
                     default_browser = choice
                     break
 
-        # FIXME the way this is written we'll never *NOT* have a compatible 'browser'
-        # because `terminal` is registered in default_authenticate as a real value
-        # the warning for No compatible browser never triggers
-
-        if default_browser == "terminal":
+        if default_browser is None:
             if len(browsers) > 0:
                 browser_name = browsers[0]["name"].lower()
 
@@ -56,4 +54,4 @@ try:
                         default_browser = choice
                         break
 except ImportError:
-    default_browser = "terminal"
+    default_browser = None

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -424,13 +424,13 @@ class Client:
                     options = webdriver.EdgeOptions()
                     driver = webdriver.Edge(options=options)
                     print("Opening Edge for authentication...")
-                case "terminal":
-                    print("Open authentication URL in your browser:")
-                    print(auth_url)
-                case _:
+                case None:
                     print(
                         "WARNING: No compatible browser detected (chrome, firefox, edge), defaulting to terminal"
                     )
+                    print("Open authentication URL in your browser:")
+                    print(auth_url)
+                case "terminal":
                     print("Open authentication URL in your browser:")
                     print(auth_url)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -38,6 +38,16 @@ def test_browser_detection_env_var(mock_installed_browsers):
         assert labapi.browser.default_browser == "firefox"
 
 
+def test_browser_detection_env_var_terminal(mock_installed_browsers):
+    """Test manual terminal mode remains an explicit browser choice."""
+    with patch("os.getenv", return_value="terminal"):
+        if "labapi.browser" in sys.modules:
+            del sys.modules["labapi.browser"]
+        import labapi.browser
+
+        assert labapi.browser.default_browser == "terminal"
+
+
 def test_browser_detection_default_system(mock_installed_browsers):
     """Test browser selection based on system default."""
     mock_installed_browsers[
@@ -68,7 +78,7 @@ def test_browser_detection_fallback_list(mock_installed_browsers):
 
 
 def test_browser_detection_terminal_fallback(mock_installed_browsers):
-    """Test fallback to 'terminal' when no compatible browser is found."""
+    """Test no compatible browser leaves detection unset."""
     mock_installed_browsers["what_is_the_default_browser"].return_value = None
     mock_installed_browsers["browsers"].return_value = []
 
@@ -77,14 +87,14 @@ def test_browser_detection_terminal_fallback(mock_installed_browsers):
             del sys.modules["labapi.browser"]
         import labapi.browser
 
-        assert labapi.browser.default_browser == "terminal"
+        assert labapi.browser.default_browser is None
 
 
 def test_browser_detection_import_error():
-    """Test fallback to 'terminal' when installed_browsers cannot be imported."""
+    """Test missing installed_browsers leaves detection unset."""
     with patch.dict("sys.modules", {"installed_browsers": None}):
         if "labapi.browser" in sys.modules:
             del sys.modules["labapi.browser"]
         import labapi.browser
 
-        assert labapi.browser.default_browser == "terminal"
+        assert labapi.browser.default_browser is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -166,6 +166,60 @@ class TestClientUnit:
         assert client._base_url is not None
         assert client._akid is not None
 
+    def test_default_authenticate_warns_when_no_browser_detected(
+        self, monkeypatch, capsys
+    ):
+        """Test default_authenticate warns before terminal fallback on detection failure."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        expected_user = Mock()
+
+        monkeypatch.setattr("labapi.client.default_browser", None)
+        monkeypatch.setattr(
+            client,
+            "generate_auth_url",
+            Mock(return_value="https://api.test.com/auth"),
+        )
+        monkeypatch.setattr(
+            client,
+            "collect_auth_response",
+            Mock(return_value=expected_user),
+        )
+
+        result = client.default_authenticate()
+        output = capsys.readouterr().out
+
+        assert result is expected_user
+        assert "WARNING: No compatible browser detected" in output
+        assert "Open authentication URL in your browser:" in output
+        assert "https://api.test.com/auth" in output
+
+    def test_default_authenticate_terminal_choice_does_not_warn(
+        self, monkeypatch, capsys
+    ):
+        """Test explicit terminal mode skips the missing-browser warning."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        expected_user = Mock()
+
+        monkeypatch.setattr("labapi.client.default_browser", "terminal")
+        monkeypatch.setattr(
+            client,
+            "generate_auth_url",
+            Mock(return_value="https://api.test.com/auth"),
+        )
+        monkeypatch.setattr(
+            client,
+            "collect_auth_response",
+            Mock(return_value=expected_user),
+        )
+
+        result = client.default_authenticate()
+        output = capsys.readouterr().out
+
+        assert result is expected_user
+        assert "WARNING: No compatible browser detected" not in output
+        assert "Open authentication URL in your browser:" in output
+        assert "https://api.test.com/auth" in output
+
 
 class TestClientIntegration:
     """Integration tests with MockClient and real objects."""


### PR DESCRIPTION
## Summary
- let browser detection return `None` when no compatible browser is detected, while preserving explicit `LA_AUTH_BROWSER=terminal`
- warn in `default_authenticate()` only for true detection failures before falling back to the terminal URL flow
- add focused browser and client tests covering detection failure, explicit terminal mode, and auth-time warning behavior

Closes #39

## Testing
- uv run pytest tests/test_browser.py tests/test_client.py -p no:cacheprovider