### PR TITLE
Rewind seekable attachment streams before upload

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -124,6 +124,8 @@ class Entries(Sequence["Entry[Any]"]):
         """
         if issubclass(cls, AttachmentEntry):
             assert isinstance(data, Attachment)
+            if data._backing.seekable():  # pyright: ignore[reportPrivateUsage]
+                data._backing.seek(0)  # pyright: ignore[reportPrivateUsage]
             entry_tree = self._user.api_post(
                 "entries/add_attachment",
                 data._backing,  # pyright: ignore[reportPrivateUsage, reportArgumentType]

--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -112,6 +112,8 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         # NOTE: this implicitly invalidates all previous Attachments
         # NOTE: if every time content is called we give a new copy anyways that's fine
         #       (see get_attachment())
+        if value._backing.seekable():  # pyright: ignore[reportPrivateUsage]
+            value._backing.seek(0)  # pyright: ignore[reportPrivateUsage]
 
         self._user.api_post(
             "entries/update_attachment",

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -121,6 +121,32 @@ class TestAttachmentEntryIntegration:
         assert api_call[1]["caption"] == "New caption"
         assert api_call[1]["eid"] == "eid_att"
 
+    def test_attachment_entry_content_setter_rewinds_seekable_stream(
+        self, client, user: User
+    ):
+        """Test AttachmentEntry.content rewinds seekable uploads before API calls."""
+        entry = AttachmentEntry("eid_att", "Old caption", user)
+
+        backing = BytesIO(b"New file content")
+        new_attachment = Attachment(
+            backing=backing,
+            mime_type="text/plain",
+            filename="new_file.txt",
+            caption="New caption",
+        )
+        new_attachment.read(4)
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entry>
+            <success>true</success>
+        </entry>
+        """
+
+        entry.content = new_attachment
+
+        assert backing.tell() == 0
+        client.api_log
+
     def test_attachment_entry_get_attachment_caching(self, client, user: User):
         """Test AttachmentEntry.get_attachment caches the result."""
         entry = AttachmentEntry("eid_att", "Caption", user)

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -164,6 +164,35 @@ class TestEntriesIntegration:
         assert api_call[1]["pid"] == "test_page_id"
         assert api_call[1]["nbid"] == "test_notebook_id"
 
+    def test_entries_create_attachment_rewinds_seekable_stream(
+        self, client, user: User, mock_page
+    ):
+        """Test Entries.create rewinds seekable attachments before upload."""
+        entries = Entries([], user, mock_page)
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <response></response>
+            <entry>
+                <eid>rewound_attachment_eid</eid>
+            </entry>
+        </entries>
+        """
+
+        backing = BytesIO(b"File content")
+        attachment = Attachment(
+            backing=backing,
+            mime_type="text/plain",
+            filename="test.txt",
+            caption="Test file",
+        )
+        attachment.read(4)
+
+        entries.create(AttachmentEntry, attachment)
+
+        assert backing.tell() == 0
+        client.api_log
+
     def test_entries_create_json_entry(self, client, user: User, mock_page):
         """Test Entries.create_json_entry creates both attachment and text entry."""
         entries = Entries([], user, mock_page)


### PR DESCRIPTION
## Summary
- rewind seekable attachment streams before both add and update upload calls
- preserve existing behavior for non-seekable streams by only seeking when supported
- add regression tests that reuse attachments from a non-zero stream position on both create and update paths

Closes #52

## Testing
- uv run pytest tests/entry/test_collection.py tests/entry/entries/test_attachment.py -p no:cacheprovider