### PR TITLE
Return independent attachment handles

### DIFF
--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -39,6 +39,26 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         self._filename = None
         self._mime_type = None
 
+    def _copy_cached_attachment(self, use_tempfile: bool) -> Attachment:
+        """Return an isolated attachment handle backed by a copy of cached data."""
+        assert self._filedata is not None
+
+        if use_tempfile:
+            output = TemporaryFile()
+        else:
+            output = BytesIO()
+
+        self._filedata.seek(0)
+        output.write(self._filedata.read())
+        output.seek(0)
+
+        return Attachment(
+            output,
+            self._filedata.mime_type,
+            self._filedata.filename,
+            self._filedata.caption,
+        )
+
     def get_attachment(self, use_tempfile: bool = False) -> Attachment:
         """Retrieves the attachment data.
 
@@ -50,18 +70,12 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
                              Defaults to False.
         :returns: An :class:`~labapi.entry.attachment.Attachment` object containing the file data and metadata.
         """
-        # BUG: currently the implementation means that the backing buffer can be used while a reference is maintained
-        #      to it
-        # TODO: we should probably return a new temporary copy every time it's asked for, tbh?
         if self._filedata is None or self._filedata.closed:
             attachment = self._user.client.stream_api_get(
                 "entries/entry_attachment", uid=self._user.id, eid=self.id
             )
 
-            if use_tempfile:
-                output = TemporaryFile()
-            else:
-                output = BytesIO()
+            output = TemporaryFile() if use_tempfile else BytesIO()
 
             try:
                 while True:
@@ -86,7 +100,7 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
 
             self._filedata = Attachment(output, mime_type, filename, self._data)
 
-        return self._filedata
+        return self._copy_cached_attachment(use_tempfile)
 
     @property
     @override

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -122,7 +122,7 @@ class TestAttachmentEntryIntegration:
         assert api_call[1]["eid"] == "eid_att"
 
     def test_attachment_entry_get_attachment_caching(self, client, user: User):
-        """Test AttachmentEntry.get_attachment caches the result."""
+        """Test AttachmentEntry.get_attachment reuses download cache without sharing handles."""
         entry = AttachmentEntry("eid_att", "Caption", user)
 
         # Mock stream_api_get
@@ -146,5 +146,12 @@ class TestAttachmentEntryIntegration:
         attachment2 = entry.get_attachment()
         assert client.stream_api_get.call_count == 1  # Not called again
 
-        # Should be same object
-        assert attachment1 is attachment2
+        assert attachment1 is not attachment2
+
+        attachment1.read(1)
+        assert attachment2.read() == b"Content"
+
+        attachment1.close()
+        attachment3 = entry.get_attachment()
+        assert client.stream_api_get.call_count == 1
+        assert attachment3.read() == b"Content"


### PR DESCRIPTION
## Summary
- keep attachment download caching but return a fresh `Attachment` handle on each access
- isolate caller `read()`, `seek()`, and `close()` state from the cached backing buffer and from other callers
- update attachment-entry tests to prove the entry only downloads once while successive handles remain independent

Closes #32

## Testing
- uv run pytest tests/entry/entries/test_attachment.py -p no:cacheprovider