### PR TITLE
Parse XML responses from raw bytes

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -351,9 +351,7 @@ class Client:
         :raises RuntimeError: If the API request fails or the response is not valid XML.
         """
 
-        return fromstring(
-            bytes(self.raw_api_get(api_method_uri, **kwargs).text, encoding="utf-8")
-        )
+        return fromstring(self.raw_api_get(api_method_uri, **kwargs).content)
 
     def api_post(
         self,
@@ -375,11 +373,7 @@ class Client:
         :raises RuntimeError: If the API request fails or the response is not valid XML.
         """
 
-        return fromstring(
-            bytes(
-                self.raw_api_post(api_method_uri, body, **kwargs).text, encoding="utf-8"
-            )
-        )
+        return fromstring(self.raw_api_post(api_method_uri, body, **kwargs).content)
 
     def default_authenticate(self) -> User:
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -122,6 +122,38 @@ class TestClientUnit:
         assert "redirect_uri=http%3A%2F%2Flocalhost%3A8089%2F" in auth_url
         assert "akid=test_akid" in auth_url
 
+    def test_client_api_get_parses_raw_response_bytes(self):
+        """Test Client.api_get parses response.content rather than re-encoded text."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = Response()
+        response.status_code = 200
+        response.encoding = "iso-8859-1"
+        response._content = (
+            b'<?xml version="1.0" encoding="ISO-8859-1"?>'
+            b"<root><value>caf\xe9</value></root>"
+        )
+        client.raw_api_get = Mock(return_value=response)  # pyright: ignore[reportAttributeAccessIssue]
+
+        result = client.api_get("test_endpoint")
+
+        assert result.findtext("./value") == "café"
+
+    def test_client_api_post_parses_raw_response_bytes(self):
+        """Test Client.api_post parses response.content rather than re-encoded text."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        response = Response()
+        response.status_code = 200
+        response.encoding = "iso-8859-1"
+        response._content = (
+            b'<?xml version="1.0" encoding="ISO-8859-1"?>'
+            b"<root><value>caf\xe9</value></root>"
+        )
+        client.raw_api_post = Mock(return_value=response)  # pyright: ignore[reportAttributeAccessIssue]
+
+        result = client.api_post("test_endpoint", {"data": "test"})
+
+        assert result.findtext("./value") == "café"
+
     def test_client_handle_request_status_success(self):
         """Test Client._handle_request_status with successful response."""
         response = Mock(spec=Response)


### PR DESCRIPTION
## Summary
- parse XML API responses from raw `response.content` bytes instead of round-tripping through `response.text`
- preserve encoding declarations from the upstream XML payload rather than forcing UTF-8 re-encoding
- add focused client tests covering both `api_get()` and `api_post()` with non-UTF-8 XML bytes

Closes #55

## Testing
- uv run pytest tests/test_client.py -p no:cacheprovider