### PR TITLE
Preserve unsupported page entries instead of dropping them

### DIFF
--- a/src/labapi/__init__.py
+++ b/src/labapi/__init__.py
@@ -21,6 +21,7 @@ from .entry import (
     HeaderEntry,
     PlainTextEntry,
     TextEntry,
+    UnknownEntry,
     WidgetEntry,
 )
 from .exceptions import (
@@ -57,6 +58,7 @@ __all__ = [
     "NotebookPath",
     "TextEntry",
     "TraversalError",
+    "UnknownEntry",
     "User",
     "WidgetEntry",
 ]

--- a/src/labapi/entry/__init__.py
+++ b/src/labapi/entry/__init__.py
@@ -11,6 +11,7 @@ from .comment import Comment
 from .entries.attachment import AttachmentEntry
 from .entries.base import Entry
 from .entries.text import HeaderEntry, PlainTextEntry, TextEntry
+from .entries.unknown import UnknownEntry
 from .entries.widget import WidgetEntry
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     "HeaderEntry",
     "PlainTextEntry",
     "TextEntry",
+    "UnknownEntry",
     "WidgetEntry",
 ]

--- a/src/labapi/entry/entries/__init__.py
+++ b/src/labapi/entry/entries/__init__.py
@@ -8,6 +8,7 @@ and attachment entries.
 from .attachment import AttachmentEntry
 from .base import Entry
 from .text import HeaderEntry, PlainTextEntry, TextEntry
+from .unknown import UnknownEntry
 from .widget import WidgetEntry
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "HeaderEntry",
     "PlainTextEntry",
     "TextEntry",
+    "UnknownEntry",
     "WidgetEntry",
 ]

--- a/src/labapi/entry/entries/unknown.py
+++ b/src/labapi/entry/entries/unknown.py
@@ -1,0 +1,35 @@
+"""Unknown entry fallback type."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, override
+
+from .base import Entry
+
+if TYPE_CHECKING:
+    from labapi.user import User
+
+
+class UnknownEntry(Entry[str], part_type="unknown entry"):
+    """Fallback entry wrapper for unimplemented or unknown upstream part types."""
+
+    def __init__(self, eid: str, data: str, user: User, part_type: str):
+        super().__init__(eid, data, user)
+        self._source_part_type = part_type
+
+    @property
+    @override
+    def content_type(self) -> str:
+        return self._source_part_type
+
+    @property
+    @override
+    def content(self) -> str:
+        return self._data
+
+    @content.setter
+    @override
+    def content(self, value: str) -> None:
+        raise NotImplementedError(
+            f"Cannot update unsupported entry type '{self._source_part_type}'"
+        )

--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Literal, cast, override, Self
 
-from labapi.entry import Attachment, Entries, Entry
+from labapi.entry import Attachment, Entries, Entry, UnknownEntry
 from labapi.util import ALL_PART_TYPES, InsertBehavior, extract_etree
 
 from .mixins import AbstractTreeContainer, AbstractTreeNode
@@ -103,16 +103,32 @@ class NotebookPage(AbstractTreeNode):
                     else:
                         warnings.warn(
                             f"Entry type '{part_type}' (ID: {entry_data['eid']}) is recognized but not "
-                            f"implemented in labapi. Skipping this entry.",
+                            f"implemented in labapi. Wrapping as UnknownEntry.",
                             UserWarning,
                             stacklevel=2,
+                        )
+                        entries.append(
+                            UnknownEntry(
+                                cast(str, entry_data["eid"]),
+                                cast(str, entry_data["entry-data"]),
+                                self._user,
+                                part_type,
+                            )
                         )
                 else:
                     warnings.warn(
                         f"Unknown entry type '{part_type}' (ID: {entry_data['eid']}) encountered. "
-                        f"This entry will be skipped.",
+                        f"Wrapping as UnknownEntry.",
                         RuntimeWarning,
                         stacklevel=2,
+                    )
+                    entries.append(
+                        UnknownEntry(
+                            cast(str, entry_data["eid"]),
+                            cast(str, entry_data["entry-data"]),
+                            self._user,
+                            part_type,
+                        )
                     )
 
             self._entries = Entries(entries, self._user, self)

--- a/tests/entry/entries/test_base.py
+++ b/tests/entry/entries/test_base.py
@@ -9,6 +9,7 @@ import pytest
 from labapi.entry.entries.attachment import AttachmentEntry
 from labapi.entry.entries.base import Entry
 from labapi.entry.entries.text import HeaderEntry, PlainTextEntry, TextEntry
+from labapi.entry.entries.unknown import UnknownEntry
 from labapi.entry.entries.widget import WidgetEntry
 from labapi.user import User
 
@@ -29,6 +30,10 @@ class TestEntryUnit:
             PlainTextEntry("e", "", Mock(spec=User)).content_type == "plain text entry"
         )
         assert AttachmentEntry("e", "", Mock(spec=User)).content_type == "Attachment"
+        assert (
+            UnknownEntry("e", "", Mock(spec=User), "future entry").content_type
+            == "future entry"
+        )
 
 
 class TestEntryIntegration:

--- a/tests/tree/test_page.py
+++ b/tests/tree/test_page.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pytest
+
 from labapi import Index, Notebook, NotebookPage
-from labapi.entry import Entries
+from labapi.entry import Entries, UnknownEntry
 from labapi.user import User
 
 
@@ -108,6 +110,66 @@ class TestNotebookPageIntegration:
         entries2 = page.entries
 
         assert entries1 is entries2
+        client.clear_log()
+
+    def test_page_entries_wrap_known_unimplemented_type(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test NotebookPage.entries preserves recognized-but-unimplemented entries."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_log()
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <entry>
+                <eid>entry_unknown_known</eid>
+                <part-type>sketch entry</part-type>
+                <attach-file-name></attach-file-name>
+                <attach-content-type></attach-content-type>
+                <entry-data><![CDATA[sketch payload]]></entry-data>
+            </entry>
+        </entries>
+        """
+
+        with pytest.warns(UserWarning, match="Wrapping as UnknownEntry"):
+            entries = page.entries
+
+        assert len(entries) == 1
+        assert isinstance(entries[0], UnknownEntry)
+        assert entries[0].content_type == "sketch entry"
+        assert entries[0].content == "sketch payload"
+        client.api_log
+        client.clear_log()
+
+    def test_page_entries_wrap_unknown_type(self, client, notebook_tree: Notebook):
+        """Test NotebookPage.entries preserves truly unknown entries."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_log()
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <entry>
+                <eid>entry_unknown_new</eid>
+                <part-type>future entry</part-type>
+                <attach-file-name></attach-file-name>
+                <attach-content-type></attach-content-type>
+                <entry-data><![CDATA[future payload]]></entry-data>
+            </entry>
+        </entries>
+        """
+
+        with pytest.warns(RuntimeWarning, match="Wrapping as UnknownEntry"):
+            entries = page.entries
+
+        assert len(entries) == 1
+        assert isinstance(entries[0], UnknownEntry)
+        assert entries[0].content_type == "future entry"
+        assert entries[0].content == "future payload"
+        client.api_log
         client.clear_log()
 
     def test_page_refresh(self, client, notebook_tree: Notebook):


### PR DESCRIPTION
## Summary
- introduce `UnknownEntry` as a fallback wrapper for unimplemented and truly unknown upstream page entry types
- keep the existing warnings, but stop silently dropping those entries during `NotebookPage.entries` reads
- add focused tests proving both recognized-but-unimplemented and unknown entry types are preserved with their original upstream `part-type`

Closes #47

## Testing
- uv run pytest tests/tree/test_page.py tests/entry/entries/test_base.py -p no:cacheprovider