### PR TITLE
Add typed Entries factory helpers

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Type, TypeVar, overload, override
 from labapi.util import extract_etree
 
 from .attachment import Attachment
-from .entries import AttachmentEntry, Entry, TextEntry
+from .entries import AttachmentEntry, Entry, HeaderEntry, PlainTextEntry, TextEntry
 
 E = TypeVar("E", bound="Entry[Any]")
 
@@ -153,3 +153,19 @@ class Entries(Sequence["Entry[Any]"]):
 
         self._entries.append(entry)
         return entry
+
+    def text(self, content: str) -> TextEntry:
+        """Create a rich text entry."""
+        return self.create(TextEntry, content)
+
+    def plain_text(self, content: str) -> PlainTextEntry:
+        """Create a plain text entry."""
+        return self.create(PlainTextEntry, content)
+
+    def header(self, content: str) -> HeaderEntry:
+        """Create a header entry."""
+        return self.create(HeaderEntry, content)
+
+    def attachment(self, data: Attachment) -> AttachmentEntry:
+        """Create an attachment entry."""
+        return self.create(AttachmentEntry, data)

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -79,6 +79,48 @@ class TestEntriesUnit:
         entry_ids = [entry.id for entry in entries]
         assert entry_ids == ["eid_1", "eid_2", "eid_3"]
 
+    @pytest.mark.parametrize(
+        "method_name,expected_cls,data",
+        [
+            ("text", TextEntry, "<p>Text</p>"),
+            ("plain_text", PlainTextEntry, "Plain text"),
+            ("header", HeaderEntry, "<h1>Header</h1>"),
+        ],
+    )
+    def test_text_factory_methods_delegate_to_create(
+        self, method_name: str, expected_cls: type, data: str
+    ):
+        """Test text-like factory helpers forward to Entries.create unchanged."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        entries = Entries([], mock_user, mock_page)
+        expected_entry = Mock(spec=expected_cls)
+        entries.create = Mock(return_value=expected_entry)  # pyright: ignore[reportAttributeAccessIssue]
+
+        result = getattr(entries, method_name)(data)
+
+        assert result is expected_entry
+        entries.create.assert_called_once_with(expected_cls, data)
+
+    def test_attachment_factory_method_delegates_to_create(self):
+        """Test attachment helper forwards to Entries.create unchanged."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        entries = Entries([], mock_user, mock_page)
+        attachment = Attachment(
+            backing=BytesIO(b"File content"),
+            mime_type="text/plain",
+            filename="test.txt",
+            caption="Test file",
+        )
+        expected_entry = Mock(spec=AttachmentEntry)
+        entries.create = Mock(return_value=expected_entry)  # pyright: ignore[reportAttributeAccessIssue]
+
+        result = entries.attachment(attachment)
+
+        assert result is expected_entry
+        entries.create.assert_called_once_with(AttachmentEntry, attachment)
+
 
 class TestEntriesIntegration:
     """Integration tests with real objects and mocked API."""


### PR DESCRIPTION
## Summary
- add `Entries.text()`, `plain_text()`, `header()`, and `attachment()` as thin typed helpers over `Entries.create(...)`
- keep the generic `create()` path as the shared implementation so the convenience methods cannot drift in behavior
- add collection tests that prove each helper delegates to `create()` with the expected entry class and payload

Closes #50

## Testing
- uv run pytest tests/entry/test_collection.py -p no:cacheprovider