### PR TITLE
Pass optional client_ip through attachment uploads

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -100,13 +100,19 @@ class Entries(Sequence["Entry[Any]"]):
 
     @overload
     def create(
-        self, cls: Type[AttachmentEntry], data: Attachment
+        self,
+        cls: Type[AttachmentEntry],
+        data: Attachment,
+        *,
+        client_ip: str | None = None,
     ) -> AttachmentEntry: ...
 
     @overload
-    def create(self, cls: Type[E], data: str) -> E: ...
+    def create(self, cls: Type[E], data: str, *, client_ip: str | None = None) -> E: ...
 
-    def create(self, cls: Type[E], data: str | Attachment) -> E:
+    def create(
+        self, cls: Type[E], data: str | Attachment, *, client_ip: str | None = None
+    ) -> E:
         """Creates a new entry on the page.
 
         This method supports creating any entry type by passing the entry class directly,
@@ -119,21 +125,26 @@ class Entries(Sequence["Entry[Any]"]):
         :param data: The content of the entry. For text-based entries, this should be a string.
                     For :class:`~labapi.entry.entries.AttachmentEntry`, this should be an
                     :class:`~labapi.entry.Attachment` object.
+        :param client_ip: Optional end-user IP to pass through on attachment uploads.
         :returns: The newly created entry object of the specified type.
         :raises RuntimeError: If the API call to create the entry fails.
         """
         if issubclass(cls, AttachmentEntry):
             assert isinstance(data, Attachment)
+            upload_kwargs = {
+                "filename": data.filename,
+                "caption": data.caption,
+                "nbid": self._page.root.id,
+                "pid": self._page.id,
+                "change_description": "File uploaded via API",
+            }
+            if client_ip is not None:
+                upload_kwargs["client_ip"] = client_ip
             entry_tree = self._user.api_post(
                 "entries/add_attachment",
                 data._backing,  # pyright: ignore[reportPrivateUsage, reportArgumentType]
-                filename=data.filename,
-                caption=data.caption,
-                nbid=self._page.root.id,
-                pid=self._page.id,
-                change_description="File uploaded via API",
+                **upload_kwargs,
             )
-            # TODO client_ip should be the end user ip (allow this to be set?)
 
             eid = extract_etree(entry_tree, {"entry": {"eid": str}})["eid"]
             entry = cls(eid, data.caption, self._user)

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -163,6 +163,35 @@ class TestEntriesIntegration:
         assert api_call[1]["caption"] == "Test file"
         assert api_call[1]["pid"] == "test_page_id"
         assert api_call[1]["nbid"] == "test_notebook_id"
+        assert "client_ip" not in api_call[1]
+
+    def test_entries_create_attachment_with_client_ip(
+        self, client, user: User, mock_page
+    ):
+        """Test Entries.create passes through client_ip for attachment uploads."""
+        entries = Entries([], user, mock_page)
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <response></response>
+            <entry>
+                <eid>new_attachment_eid</eid>
+            </entry>
+        </entries>
+        """
+
+        attachment = Attachment(
+            backing=BytesIO(b"File content"),
+            mime_type="text/plain",
+            filename="test.txt",
+            caption="Test file",
+        )
+
+        entries.create(AttachmentEntry, attachment, client_ip="203.0.113.7")
+
+        api_call = client.api_log
+        assert api_call[0] == "entries/add_attachment"
+        assert api_call[1]["client_ip"] == "203.0.113.7"
 
     def test_entries_create_json_entry(self, client, user: User, mock_page):
         """Test Entries.create_json_entry creates both attachment and text entry."""


### PR DESCRIPTION
## Summary
- add an optional `client_ip` keyword parameter to `Entries.create()` for attachment uploads
- pass that value through to `entries/add_attachment` only when explicitly provided
- add collection tests proving the upload request omits `client_ip` by default and includes it when requested

Closes #41

## Testing
- uv run pytest tests/entry/test_collection.py -p no:cacheprovider