### PR TITLE
Add entry lookup and filter helpers

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -60,6 +60,25 @@ class Entries(Sequence["Entry[Any]"]):
     def __len__(self):
         return len(self._entries)
 
+    def get_by_id(self, eid: str) -> Entry[Any]:
+        """Return the entry with the given ID or raise ``KeyError``."""
+        for entry in self._entries:
+            if entry.id == eid:
+                return entry
+        raise KeyError(f"Entry with id '{eid}' not found")
+
+    def of_type(self, cls: Type[E]) -> list[E]:
+        """Return all entries that are instances of the requested class."""
+        return [entry for entry in self._entries if isinstance(entry, cls)]
+
+    def attachments(self) -> list[AttachmentEntry]:
+        """Return all attachment entries."""
+        return self.of_type(AttachmentEntry)
+
+    def texts(self) -> list[TextEntry]:
+        """Return all rich text entries."""
+        return self.of_type(TextEntry)
+
     # TODO delete entries
 
     def create_json_entry(self, data: JsonData) -> tuple[AttachmentEntry, TextEntry]:

--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -100,13 +100,19 @@ class Entries(Sequence["Entry[Any]"]):
 
     @overload
     def create(
-        self, cls: Type[AttachmentEntry], data: Attachment
+        self,
+        cls: Type[AttachmentEntry],
+        data: Attachment,
+        *,
+        client_ip: str | None = None,
     ) -> AttachmentEntry: ...
 
     @overload
-    def create(self, cls: Type[E], data: str) -> E: ...
+    def create(self, cls: Type[E], data: str, *, client_ip: str | None = None) -> E: ...
 
-    def create(self, cls: Type[E], data: str | Attachment) -> E:
+    def create(
+        self, cls: Type[E], data: str | Attachment, *, client_ip: str | None = None
+    ) -> E:
         """Creates a new entry on the page.
 
         This method supports creating any entry type by passing the entry class directly,
@@ -119,21 +125,26 @@ class Entries(Sequence["Entry[Any]"]):
         :param data: The content of the entry. For text-based entries, this should be a string.
                     For :class:`~labapi.entry.entries.AttachmentEntry`, this should be an
                     :class:`~labapi.entry.Attachment` object.
+        :param client_ip: Optional end-user IP to pass through on attachment uploads.
         :returns: The newly created entry object of the specified type.
         :raises RuntimeError: If the API call to create the entry fails.
         """
         if issubclass(cls, AttachmentEntry):
             assert isinstance(data, Attachment)
+            upload_kwargs = {
+                "filename": data.filename,
+                "caption": data.caption,
+                "nbid": self._page.root.id,
+                "pid": self._page.id,
+                "change_description": "File uploaded via API",
+            }
+            if client_ip is not None:
+                upload_kwargs["client_ip"] = client_ip
             entry_tree = self._user.api_post(
                 "entries/add_attachment",
                 data._backing,  # pyright: ignore[reportPrivateUsage, reportArgumentType]
-                filename=data.filename,
-                caption=data.caption,
-                nbid=self._page.root.id,
-                pid=self._page.id,
-                change_description="File uploaded via API",
+                **upload_kwargs,
             )
-            # TODO client_ip should be the end user ip (allow this to be set?)
 
             eid = extract_etree(entry_tree, {"entry": {"eid": str}})["eid"]
             entry = cls(eid, data.caption, self._user)

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -163,6 +163,35 @@ class TestEntriesIntegration:
         assert api_call[1]["caption"] == "Test file"
         assert api_call[1]["pid"] == "test_page_id"
         assert api_call[1]["nbid"] == "test_notebook_id"
+        assert "client_ip" not in api_call[1]
+
+    def test_entries_create_attachment_with_client_ip(
+        self, client, user: User, mock_page
+    ):
+        """Test Entries.create passes through client_ip for attachment uploads."""
+        entries = Entries([], user, mock_page)
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <response></response>
+            <entry>
+                <eid>new_attachment_eid</eid>
+            </entry>
+        </entries>
+        """
+
+        attachment = Attachment(
+            backing=BytesIO(b"File content"),
+            mime_type="text/plain",
+            filename="test.txt",
+            caption="Test file",
+        )
+
+        entries.create(AttachmentEntry, attachment, client_ip="203.0.113.7")
+
+        api_call = client.api_log
+        assert api_call[0] == "entries/add_attachment"
+        assert api_call[1]["client_ip"] == "203.0.113.7"
 
     def test_entries_create_json_entry(self, client, user: User, mock_page):
         """Test Entries.create_json_entry creates both attachment and text entry."""

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -79,6 +79,50 @@ class TestEntriesUnit:
         entry_ids = [entry.id for entry in entries]
         assert entry_ids == ["eid_1", "eid_2", "eid_3"]
 
+    def test_entries_get_by_id(self):
+        """Test Entries.get_by_id returns a matching entry."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        entry1 = TextEntry("eid_1", "<p>Entry 1</p>", mock_user)
+        entry2 = HeaderEntry("eid_2", "<h1>Header</h1>", mock_user)
+        entries = Entries([entry1, entry2], mock_user, mock_page)
+
+        assert entries.get_by_id("eid_2") is entry2
+
+    def test_entries_get_by_id_missing_raises(self):
+        """Test Entries.get_by_id raises KeyError for unknown IDs."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        entries = Entries([], mock_user, mock_page)
+
+        with pytest.raises(KeyError, match="Entry with id 'missing' not found"):
+            entries.get_by_id("missing")
+
+    def test_entries_of_type(self):
+        """Test Entries.of_type filters by entry subclass."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        entry1 = TextEntry("eid_1", "<p>Entry 1</p>", mock_user)
+        entry2 = HeaderEntry("eid_2", "<h1>Header</h1>", mock_user)
+        entry3 = PlainTextEntry("eid_3", "Plain text", mock_user)
+        entries = Entries([entry1, entry2, entry3], mock_user, mock_page)
+
+        assert entries.of_type(TextEntry) == [entry1]
+        assert entries.of_type(HeaderEntry) == [entry2]
+        assert entries.of_type(PlainTextEntry) == [entry1, entry2, entry3]
+
+    def test_entries_typed_filter_helpers(self):
+        """Test Entries convenience filter helpers."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        entry1 = TextEntry("eid_1", "<p>Entry 1</p>", mock_user)
+        entry2 = AttachmentEntry("eid_2", "Test file", mock_user)
+        entry3 = HeaderEntry("eid_3", "<h1>Header</h1>", mock_user)
+        entries = Entries([entry1, entry2, entry3], mock_user, mock_page)
+
+        assert entries.texts() == [entry1]
+        assert entries.attachments() == [entry2]
+
 
 class TestEntriesIntegration:
     """Integration tests with real objects and mocked API."""


### PR DESCRIPTION
## Summary
- add `Entries.get_by_id()` and generic `Entries.of_type()` helpers for common entry lookup/filtering
- add `Entries.attachments()` and `Entries.texts()` as small typed convenience views built on `of_type()`
- add collection tests for ID lookup, missing-entry errors, subclass filtering, and the typed convenience helpers

Closes #49

## Testing
- uv run pytest tests/entry/test_collection.py -p no:cacheprovider