### PR TITLE
Add raw and streaming User API helpers

### DIFF
--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -54,8 +54,8 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         #      to it
         # TODO: we should probably return a new temporary copy every time it's asked for, tbh?
         if self._filedata is None or self._filedata.closed:
-            attachment = self._user.client.stream_api_get(
-                "entries/entry_attachment", uid=self._user.id, eid=self.id
+            attachment = self._user.stream_api_get(
+                "entries/entry_attachment", eid=self.id
             )
 
             if use_tempfile:

--- a/src/labapi/user.py
+++ b/src/labapi/user.py
@@ -88,6 +88,14 @@ class User:
         """
         return self._client.api_get(api_method_uri, **kwargs, uid=self._id)
 
+    def raw_api_get(self, api_method_uri: str | Sequence[str], **kwargs: Any):
+        """Make a raw GET request to the API on behalf of the authenticated user."""
+        return self._client.raw_api_get(api_method_uri, **kwargs, uid=self._id)
+
+    def stream_api_get(self, api_method_uri: str | Sequence[str], **kwargs: Any):
+        """Make a streaming GET request to the API on behalf of the authenticated user."""
+        return self._client.stream_api_get(api_method_uri, **kwargs, uid=self._id)
+
     def api_post(
         self,
         api_method_uri: str | Sequence[str],
@@ -106,6 +114,24 @@ class User:
         :raises RuntimeError: If the API request fails.
         """
         return self._client.api_post(api_method_uri, body, **kwargs, uid=self._id)
+
+    def raw_api_post(
+        self,
+        api_method_uri: str | Sequence[str],
+        body: Mapping[str, str] | BufferedIOBase,
+        **kwargs: Any,
+    ):
+        """Make a raw POST request to the API on behalf of the authenticated user."""
+        return self._client.raw_api_post(api_method_uri, body, **kwargs, uid=self._id)
+
+    def stream_api_post(
+        self,
+        api_method_uri: str | Sequence[str],
+        body: Mapping[str, str] | BufferedIOBase,
+        **kwargs: Any,
+    ):
+        """Make a streaming POST request to the API on behalf of the authenticated user."""
+        return self._client.stream_api_post(api_method_uri, body, **kwargs, uid=self._id)
 
     def get_max_upload_size(self) -> int:
         """Retrieves the maximum allowed file upload size for the user from the LabArchives API.

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -48,7 +48,7 @@ class TestAttachmentEntryIntegration:
             yield b"content"
             return mock_response
 
-        client.stream_api_get = Mock(return_value=mock_stream())
+        user.stream_api_get = Mock(return_value=mock_stream())
 
         # Get attachment
         attachment = entry.get_attachment(use_tempfile=False)
@@ -63,9 +63,7 @@ class TestAttachmentEntryIntegration:
         assert attachment.read() == b"Test file content"
 
         # Verify API was called correctly
-        client.stream_api_get.assert_called_once_with(
-            "entries/entry_attachment", uid=user.id, eid="eid_att"
-        )
+        user.stream_api_get.assert_called_once_with("entries/entry_attachment", eid="eid_att")
 
     def test_attachment_entry_content_getter(self, client, user: User):
         """Test AttachmentEntry.content getter returns attachment."""
@@ -82,7 +80,7 @@ class TestAttachmentEntryIntegration:
             yield b"PDF content"
             return mock_response
 
-        client.stream_api_get = Mock(return_value=mock_stream())
+        user.stream_api_get = Mock(return_value=mock_stream())
 
         # Access content property
         attachment = entry.content
@@ -136,15 +134,15 @@ class TestAttachmentEntryIntegration:
             yield b"Content"
             return mock_response
 
-        client.stream_api_get = Mock(return_value=mock_stream())
+        user.stream_api_get = Mock(return_value=mock_stream())
 
         # First call
         attachment1 = entry.get_attachment()
-        assert client.stream_api_get.call_count == 1
+        assert user.stream_api_get.call_count == 1
 
         # Second call should use cached data
         attachment2 = entry.get_attachment()
-        assert client.stream_api_get.call_count == 1  # Not called again
+        assert user.stream_api_get.call_count == 1  # Not called again
 
         # Should be same object
         assert attachment1 is attachment2

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -56,6 +56,66 @@ class TestUserUnit:
         )
         assert result is mock_element
 
+    def test_user_raw_api_get_adds_uid(self):
+        """Test User.raw_api_get adds uid to the API call."""
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_client.raw_api_get.return_value = mock_response
+
+        user = User("user_123", "test@example.com", [], mock_client)
+        result = user.raw_api_get("test_endpoint", param1="value1")
+
+        mock_client.raw_api_get.assert_called_once_with(
+            "test_endpoint", param1="value1", uid="user_123"
+        )
+        assert result is mock_response
+
+    def test_user_raw_api_post_adds_uid(self):
+        """Test User.raw_api_post adds uid to the API call."""
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_client.raw_api_post.return_value = mock_response
+
+        user = User("user_456", "test@example.com", [], mock_client)
+        result = user.raw_api_post(
+            "test_endpoint", {"data": "test"}, param1="value1"
+        )
+
+        mock_client.raw_api_post.assert_called_once_with(
+            "test_endpoint", {"data": "test"}, param1="value1", uid="user_456"
+        )
+        assert result is mock_response
+
+    def test_user_stream_api_get_adds_uid(self):
+        """Test User.stream_api_get adds uid to the API call."""
+        mock_client = Mock()
+        stream = iter([b"chunk"])
+        mock_client.stream_api_get.return_value = stream
+
+        user = User("user_123", "test@example.com", [], mock_client)
+        result = user.stream_api_get("test_endpoint", param1="value1")
+
+        mock_client.stream_api_get.assert_called_once_with(
+            "test_endpoint", param1="value1", uid="user_123"
+        )
+        assert result is stream
+
+    def test_user_stream_api_post_adds_uid(self):
+        """Test User.stream_api_post adds uid to the API call."""
+        mock_client = Mock()
+        stream = iter([b"chunk"])
+        mock_client.stream_api_post.return_value = stream
+
+        user = User("user_456", "test@example.com", [], mock_client)
+        result = user.stream_api_post(
+            "test_endpoint", {"data": "test"}, param1="value1"
+        )
+
+        mock_client.stream_api_post.assert_called_once_with(
+            "test_endpoint", {"data": "test"}, param1="value1", uid="user_456"
+        )
+        assert result is stream
+
 
 class TestUserIntegration:
     """Integration tests with real objects and mocked API."""
@@ -113,6 +173,22 @@ class TestUserIntegration:
         api_call = client.api_log
         assert api_call[0] == "test_post_endpoint"
         assert api_call[1]["param1"] == "value1"
+        assert api_call[1]["uid"] == "testid1"
+
+    def test_user_raw_api_post_full_flow(self, client, user: User):
+        """Test User.raw_api_post full flow with MockClient."""
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <result>
+            <success>true</success>
+        </result>
+        """
+
+        response = user.raw_api_post("test_post_endpoint", {"data": "test_data"})
+
+        assert response.status_code == 200
+
+        api_call = client.api_log
+        assert api_call[0] == "test_post_endpoint"
         assert api_call[1]["uid"] == "testid1"
 
     def test_user_get_max_upload_size(self, client, user: User):


### PR DESCRIPTION
## Summary
- add raw and streaming GET/POST passthrough helpers on `User`, keeping the authenticated `uid` injection pattern consistent with `api_get()` and `api_post()`
- update attachment downloads to use `user.stream_api_get(...)` instead of reaching through `user.client`
- add focused user and attachment-entry tests for the new delegation surface

Closes #48

## Testing
- uv run pytest tests/test_user.py tests/entry/entries/test_attachment.py -p no:cacheprovider