### PR TITLE
Add lightweight NotebookPage entry listing

### DIFF
--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -47,6 +47,33 @@ class NotebookPage(AbstractTreeNode):
         super().__init__(tree_id, name, root, parent, user)
         self._entries: Entries | None = None
 
+    def list_entries(self, include_data: bool = False) -> list[dict[str, str]]:
+        """Return lightweight entry metadata for this page.
+
+        :param include_data: If ``True``, include entry payload data in the result.
+        :returns: A list of extracted entry metadata dictionaries.
+        """
+        entry_format: dict[str, type[str]] = {
+            "eid": str,
+            "part-type": str,
+            "attach-file-name": str,
+            "attach-content-type": str,
+        }
+        if include_data:
+            entry_format["entry-data"] = str
+
+        entries_tree = self._user.api_get(
+            "tree_tools/get_entries_for_page",
+            page_tree_id=self.id,
+            nbid=self.root.id,
+            entry_data=include_data,
+        )
+
+        return [
+            cast(dict[str, str], extract_etree(entry, entry_format))
+            for entry in entries_tree.iterfind(".//entry")
+        ]
+
     @property
     @override
     def id(self) -> str:
@@ -67,25 +94,7 @@ class NotebookPage(AbstractTreeNode):
         """
         if self._entries is None:
             entries: list[Entry[Any]] = []
-
-            entries_tree = self._user.api_get(
-                "tree_tools/get_entries_for_page",
-                page_tree_id=self.id,
-                nbid=self.root.id,
-                entry_data=True,
-            )
-
-            for entry in entries_tree.iterfind(".//entry"):
-                entry_data = extract_etree(
-                    entry,
-                    {
-                        "eid": str,
-                        "part-type": str,
-                        "attach-file-name": str,
-                        "attach-content-type": str,
-                        "entry-data": str,
-                    },
-                )
+            for entry_data in self.list_entries(include_data=True):
 
                 part_type = entry_data["part-type"]
 

--- a/tests/tree/test_page.py
+++ b/tests/tree/test_page.py
@@ -110,6 +110,76 @@ class TestNotebookPageIntegration:
         assert entries1 is entries2
         client.clear_log()
 
+    def test_page_list_entries_metadata_only(self, client, notebook_tree: Notebook):
+        """Test NotebookPage.list_entries fetches metadata without entry_data."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_log()
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <entry>
+                <eid>entry_1</eid>
+                <part-type>Attachment</part-type>
+                <attach-file-name>document.pdf</attach-file-name>
+                <attach-content-type>application/pdf</attach-content-type>
+            </entry>
+        </entries>
+        """
+
+        entries = page.list_entries()
+
+        assert entries == [
+            {
+                "eid": "entry_1",
+                "part-type": "Attachment",
+                "attach-file-name": "document.pdf",
+                "attach-content-type": "application/pdf",
+            }
+        ]
+
+        api_call = client.api_log
+        assert api_call[0] == "tree_tools/get_entries_for_page"
+        assert api_call[1]["entry_data"] is False
+        client.clear_log()
+
+    def test_page_list_entries_with_data(self, client, notebook_tree: Notebook):
+        """Test NotebookPage.list_entries can request entry payload data."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_log()
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <entry>
+                <eid>entry_1</eid>
+                <part-type>text entry</part-type>
+                <attach-file-name></attach-file-name>
+                <attach-content-type></attach-content-type>
+                <entry-data><![CDATA[<p>Test content</p>]]></entry-data>
+            </entry>
+        </entries>
+        """
+
+        entries = page.list_entries(include_data=True)
+
+        assert entries == [
+            {
+                "eid": "entry_1",
+                "part-type": "text entry",
+                "attach-file-name": "",
+                "attach-content-type": "",
+                "entry-data": "<p>Test content</p>",
+            }
+        ]
+
+        api_call = client.api_log
+        assert api_call[0] == "tree_tools/get_entries_for_page"
+        assert api_call[1]["entry_data"] is True
+        client.clear_log()
+
     def test_page_refresh(self, client, notebook_tree: Notebook):
         """Test NotebookPage.refresh clears cached entries."""
         page = notebook_tree[Index.Id : "page-1"]


### PR DESCRIPTION
## Summary
- add `NotebookPage.list_entries(include_data=False)` as a lightweight metadata-only path over `get_entries_for_page`
- keep the existing `entries` property behavior intact while routing its hydration through the same extractor with `include_data=True`
- add focused page tests covering both metadata-only and full-data request shapes

Closes #53

## Testing
- uv run pytest tests/tree/test_page.py -p no:cacheprovider