### PR TITLE
Expose attachment metadata from page listings

### DIFF
--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -27,17 +27,27 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
     providing access to the attachment's content, filename, and caption.
     """
 
-    def __init__(self, eid: str, caption: str, user: User):
+    def __init__(
+        self,
+        eid: str,
+        caption: str,
+        user: User,
+        *,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ):
         """Initializes an AttachmentEntry object.
 
         :param eid: The unique ID of the entry.
         :param caption: The caption associated with the attachment.
         :param user: The authenticated user.
+        :param filename: Optional filename metadata from page listing.
+        :param mime_type: Optional MIME type metadata from page listing.
         """
         super().__init__(eid, caption, user)
         self._filedata = None
-        self._filename = None
-        self._mime_type = None
+        self._filename = filename
+        self._mime_type = mime_type
 
     def get_attachment(self, use_tempfile: bool = False) -> Attachment:
         """Retrieves the attachment data.
@@ -83,6 +93,8 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
                     )
 
             output.seek(0)
+            self._filename = filename
+            self._mime_type = mime_type
 
             self._filedata = Attachment(output, mime_type, filename, self._data)
 
@@ -135,3 +147,13 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         :returns: The caption string.
         """
         return self._data
+
+    @property
+    def filename(self) -> str | None:
+        """The attachment filename when known without downloading content."""
+        return self._filename
+
+    @property
+    def mime_type(self) -> str | None:
+        """The attachment MIME type when known without downloading content."""
+        return self._mime_type

--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Literal, cast, override, Self
 
-from labapi.entry import Attachment, Entries, Entry
+from labapi.entry import Attachment, AttachmentEntry, Entries, Entry
 from labapi.util import ALL_PART_TYPES, InsertBehavior, extract_etree
 
 from .mixins import AbstractTreeContainer, AbstractTreeNode
@@ -92,14 +92,29 @@ class NotebookPage(AbstractTreeNode):
                 if part_type in ALL_PART_TYPES:
                     if Entry.is_registered(part_type):
                         # Cast extracted string values to ensure type checker knows they're not None
-                        entries.append(
-                            Entry.from_part_type(
-                                part_type,
-                                cast(str, entry_data["eid"]),
-                                cast(str, entry_data["entry-data"]),
-                                self._user,
+                        if part_type == "Attachment":
+                            entries.append(
+                                AttachmentEntry(
+                                    cast(str, entry_data["eid"]),
+                                    cast(str, entry_data["entry-data"]),
+                                    self._user,
+                                    filename=cast(
+                                        str | None, entry_data["attach-file-name"]
+                                    ),
+                                    mime_type=cast(
+                                        str | None, entry_data["attach-content-type"]
+                                    ),
+                                )
                             )
-                        )
+                        else:
+                            entries.append(
+                                Entry.from_part_type(
+                                    part_type,
+                                    cast(str, entry_data["eid"]),
+                                    cast(str, entry_data["entry-data"]),
+                                    self._user,
+                                )
+                            )
                     else:
                         warnings.warn(
                             f"Entry type '{part_type}' (ID: {entry_data['eid']}) is recognized but not "

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -27,6 +27,20 @@ class TestAttachmentEntryUnit:
 
         assert entry.caption == "My attachment caption"
 
+    def test_attachment_entry_listing_metadata(self):
+        """Test AttachmentEntry exposes filename and MIME metadata from listings."""
+        mock_user = Mock(spec=User)
+        entry = AttachmentEntry(
+            "eid_att",
+            "My attachment caption",
+            mock_user,
+            filename="document.pdf",
+            mime_type="application/pdf",
+        )
+
+        assert entry.filename == "document.pdf"
+        assert entry.mime_type == "application/pdf"
+
 
 class TestAttachmentEntryIntegration:
     """Integration tests with real objects and mocked API."""

--- a/tests/tree/test_page.py
+++ b/tests/tree/test_page.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from labapi import Index, Notebook, NotebookPage
-from labapi.entry import Entries
+from labapi.entry import AttachmentEntry, Entries
 from labapi.user import User
 
 
@@ -81,6 +81,38 @@ class TestNotebookPageIntegration:
         assert api_call[1]["page_tree_id"] == "page-1"
         assert api_call[1]["nbid"] == notebook_tree.id
         assert api_call[1]["entry_data"] is True
+        client.clear_log()
+
+    def test_page_entries_expose_attachment_listing_metadata(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test NotebookPage.entries hydrates attachment filename and MIME metadata."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_log()
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <entry>
+                <eid>entry_1</eid>
+                <part-type>Attachment</part-type>
+                <attach-file-name>document.pdf</attach-file-name>
+                <attach-content-type>application/pdf</attach-content-type>
+                <entry-data><![CDATA[Attachment caption]]></entry-data>
+            </entry>
+        </entries>
+        """
+
+        entries = page.entries
+
+        assert len(entries) == 1
+        assert isinstance(entries[0], AttachmentEntry)
+        assert entries[0].filename == "document.pdf"
+        assert entries[0].mime_type == "application/pdf"
+        assert entries[0].caption == "Attachment caption"
+
+        client.api_log
         client.clear_log()
 
     def test_page_entries_caching(self, client, notebook_tree: Notebook):


### PR DESCRIPTION
## Summary
- add optional `filename` and `mime_type` metadata fields to `AttachmentEntry`
- populate those fields from the page listing response so callers can inspect attachment metadata without downloading payloads
- add focused attachment-entry and page tests covering listing-time metadata hydration

Closes #31

## Testing
- uv run pytest tests/tree/test_page.py tests/entry/entries/test_attachment.py -p no:cacheprovider