### PR TITLE
Allow create_json_entry filename and caption overrides

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -62,7 +62,13 @@ class Entries(Sequence["Entry[Any]"]):
 
     # TODO delete entries
 
-    def create_json_entry(self, data: JsonData) -> tuple[AttachmentEntry, TextEntry]:
+    def create_json_entry(
+        self,
+        data: JsonData,
+        *,
+        filename: str | None = None,
+        caption: str | None = None,
+    ) -> tuple[AttachmentEntry, TextEntry]:
         """Creates a JSON data entry consisting of an attachment and a reference text entry.
 
         This method uploads JSON data as an attachment file and creates a
@@ -70,11 +76,14 @@ class Entries(Sequence["Entry[Any]"]):
         a formatted preview of the JSON data.
 
         :param data: The JSON-serializable data to upload.
+        :param filename: Optional stable filename for the uploaded JSON attachment.
+        :param caption: Optional label/caption for the generated attachment and reference entry.
         :returns: A tuple containing the attachment entry and the text entry.
         """
         # TODO treat this as one entry in the code
 
-        name = f"uploaded_data_{datetime.now().timestamp():.0f}.json"
+        name = filename or f"uploaded_data_{datetime.now().timestamp():.0f}.json"
+        display_caption = caption or name
 
         file_entry = self.create(
             AttachmentEntry,
@@ -82,14 +91,14 @@ class Entries(Sequence["Entry[Any]"]):
                 BytesIO(dumps(data).encode()),
                 "application/json",
                 name,
-                "Uploaded JSON file",
+                display_caption,
             ),
         )
 
         text_entry = self.create(
             TextEntry,
             f"""
-<p>Reference Attachment: {name}</p>
+<p>Reference Attachment: {display_caption}</p>
 <p>Entry ID: {file_entry.id}</p>
 <pre>
 {dumps(data, indent=4)}

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -206,3 +206,45 @@ class TestEntriesIntegration:
         assert ".json" in text_entry.content
         assert file_entry.id in text_entry.content
         client.clear_log()
+
+    def test_entries_create_json_entry_custom_filename_and_caption(
+        self, client, user: User, mock_page
+    ):
+        """Test Entries.create_json_entry accepts stable filename and caption overrides."""
+        entries = Entries([], user, mock_page)
+
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <response></response>
+            <entry>
+                <eid>json_attachment_eid</eid>
+            </entry>
+        </entries>
+        """
+        client.api_response = """<?xml version="1.0" encoding="UTF-8"?>
+        <entries>
+            <response></response>
+            <entry>
+                <eid>json_text_eid</eid>
+            </entry>
+        </entries>
+        """
+
+        file_entry, text_entry = entries.create_json_entry(
+            {"key": "value"},
+            filename="metrics.json",
+            caption="Metrics Snapshot",
+        )
+
+        assert file_entry.caption == "Metrics Snapshot"
+        assert text_entry.content.startswith("\n<p>Reference Attachment: Metrics Snapshot</p>")
+        assert "json_attachment_eid" in text_entry.content
+
+        attachment_call = client.api_log
+        assert attachment_call[0] == "entries/add_attachment"
+        assert attachment_call[1]["filename"] == "metrics.json"
+        assert attachment_call[1]["caption"] == "Metrics Snapshot"
+
+        text_call = client.api_log
+        assert text_call[0] == "entries/add_entry"
+        assert "Metrics Snapshot" in text_call[1]["entry_data"]


### PR DESCRIPTION
## Summary
- add optional `filename` and `caption` overrides to `Entries.create_json_entry()`
- keep the existing timestamp-based filename behavior when no override is supplied
- use the provided caption for both the attachment metadata and the generated reference text entry

## Testing
- uv run pytest tests/entry/test_collection.py -p no:cacheprovider

Closes #33