### PR TITLE
Filter unstable browser channels from detection

### DIFF
--- a/src/labapi/browser.py
+++ b/src/labapi/browser.py
@@ -15,21 +15,25 @@ try:
 
     import installed_browsers  # pyright: ignore[reportMissingTypeStubs]
 
+    unstable_browser_channels = ("canary", "nightly", "beta", "dev", "unstable")
+    browser_choices = ["chrome", "firefox", "edge"]  # priority in order of order
+
+    def is_stable_compatible_browser(name: str) -> bool:
+        lowered_name = name.lower()
+        return (
+            any(choice in lowered_name for choice in browser_choices)
+            and not any(channel in lowered_name for channel in unstable_browser_channels)
+        )
+
     browsers = [
         x
         for x in installed_browsers.browsers()
-        if (
-            "chrome" in x["name"].lower()
-            or "firefox" in x["name"].lower()
-            or "edge" in x["name"].lower()
-        )
+        if is_stable_compatible_browser(x["name"])
     ]
     raw_default_browser = installed_browsers.what_is_the_default_browser()
     raw_env_browser = getenv("LA_AUTH_BROWSER", "").strip().lower()
 
     default_browser = "terminal"
-
-    browser_choices = ["chrome", "firefox", "edge"]  # priority in order of order
 
     if raw_env_browser in ("chrome", "firefox", "edge", "terminal"):
         if installed_browsers.do_i_have_installed(raw_env_browser):
@@ -38,10 +42,11 @@ try:
         if raw_default_browser:
             raw_default_browser = raw_default_browser.lower()
 
-            for choice in browser_choices:
-                if choice in raw_default_browser:
-                    default_browser = choice
-                    break
+            if is_stable_compatible_browser(raw_default_browser):
+                for choice in browser_choices:
+                    if choice in raw_default_browser:
+                        default_browser = choice
+                        break
 
         # FIXME the way this is written we'll never *NOT* have a compatible 'browser'
         # because `terminal` is registered in default_authenticate as a real value

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -55,8 +55,41 @@ def test_browser_detection_default_system(mock_installed_browsers):
 def test_browser_detection_fallback_list(mock_installed_browsers):
     """Test fallback to first detected compatible browser."""
     mock_installed_browsers["what_is_the_default_browser"].return_value = None
+    mock_installed_browsers["browsers"].return_value = [{"name": "Firefox"}]
+
+    with patch("os.getenv", return_value=""):
+        if "labapi.browser" in sys.modules:
+            del sys.modules["labapi.browser"]
+        import labapi.browser
+
+        assert labapi.browser.default_browser == "firefox"
+
+
+def test_browser_detection_fallback_list_skips_unstable_channels(mock_installed_browsers):
+    """Test fallback ignores canary, nightly, beta, dev, and unstable browsers."""
+    mock_installed_browsers["what_is_the_default_browser"].return_value = None
     mock_installed_browsers["browsers"].return_value = [
-        {"name": "Firefox Nightly", "path": "/path/to/firefox"}
+        {"name": "Firefox Nightly"},
+        {"name": "Chrome Canary"},
+        {"name": "Edge Dev"},
+    ]
+
+    with patch("os.getenv", return_value=""):
+        if "labapi.browser" in sys.modules:
+            del sys.modules["labapi.browser"]
+        import labapi.browser
+
+        assert labapi.browser.default_browser == "terminal"
+
+
+def test_browser_detection_default_system_skips_unstable_channel(mock_installed_browsers):
+    """Test unstable system defaults do not block fallback to a stable browser."""
+    mock_installed_browsers[
+        "what_is_the_default_browser"
+    ].return_value = "Google Chrome Canary"
+    mock_installed_browsers["browsers"].return_value = [
+        {"name": "Firefox Nightly"},
+        {"name": "Firefox"},
     ]
 
     with patch("os.getenv", return_value=""):


### PR DESCRIPTION
## Summary
- filter beta, canary, nightly, dev, and unstable browser channels out of automatic browser detection
- stop treating unstable system-default browser names as stable Selenium targets
- add regression tests for stable fallback selection and unstable-channel rejection

## Testing
- uv run pytest tests/test_browser.py tests/test_client.py -p no:cacheprovider

Closes #13