### PR TITLE
Defer browser and dotenv initialization

### DIFF
--- a/src/labapi/browser.py
+++ b/src/labapi/browser.py
@@ -7,13 +7,21 @@ and finally any detected installed browser. If no compatible browser is found,
 it defaults to "terminal", indicating that the authentication URL should be
 opened manually by the user.
 
-The detected browser is exposed via the `default_browser` module-level variable.
+The detected browser is resolved lazily via :func:`get_default_browser`.
 """
 
-try:
-    from os import getenv
+from __future__ import annotations
 
-    import installed_browsers  # pyright: ignore[reportMissingTypeStubs]
+import os
+
+_default_browser: str | None = None
+
+
+def _detect_browser() -> str:
+    try:
+        import installed_browsers  # pyright: ignore[reportMissingTypeStubs]
+    except ImportError:
+        return "terminal"
 
     browsers = [
         x
@@ -25,10 +33,9 @@ try:
         )
     ]
     raw_default_browser = installed_browsers.what_is_the_default_browser()
-    raw_env_browser = getenv("LA_AUTH_BROWSER", "").strip().lower()
+    raw_env_browser = os.getenv("LA_AUTH_BROWSER", "").strip().lower()
 
     default_browser = "terminal"
-
     browser_choices = ["chrome", "firefox", "edge"]  # priority in order of order
 
     if raw_env_browser in ("chrome", "firefox", "edge", "terminal"):
@@ -55,5 +62,22 @@ try:
                     if choice in browser_name:
                         default_browser = choice
                         break
-except ImportError:
-    default_browser = "terminal"
+
+    return default_browser
+
+
+def get_default_browser() -> str:
+    """Detect and cache the preferred authentication browser on first use."""
+    global _default_browser
+
+    if _default_browser is None:
+        _default_browser = _detect_browser()
+
+    return _default_browser
+
+
+def __getattr__(name: str) -> str:
+    """Preserve the historical module attribute while making detection lazy."""
+    if name == "default_browser":
+        return get_default_browser()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -26,7 +26,7 @@ from requests import Response, Session
 from requests import codes as status_codes
 from requests.adapters import HTTPAdapter
 
-from .browser import default_browser
+from .browser import get_default_browser
 from .exceptions import ApiError, AuthenticationError
 from .user import User
 from .util import NotebookInit, extract_etree, to_bool
@@ -41,15 +41,17 @@ _AUTH_ERROR_CODES: frozenset[int] = frozenset(
     }
 )
 
-try:
-    from dotenv import load_dotenv
+context = ssl.create_default_context()
+
+
+def _load_dotenv() -> None:
+    """Load environment variables from a local .env file when available."""
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
 
     load_dotenv()
-except ImportError:
-    pass
-
-
-context = ssl.create_default_context()
 
 
 class _313HTTPAdapter(HTTPAdapter):
@@ -118,6 +120,9 @@ class Client:
                            Defaults to True. **Warning:** Setting this to False reduces security.
         """
         super().__init__()
+
+        if base_url is None or akid is None or akpass is None:
+            _load_dotenv()
 
         if base_url is None:
             base_url = getenv("API_URL", "https://api.labarchives.com")
@@ -405,7 +410,7 @@ class Client:
         driver = None
         options = None
         try:
-            match default_browser:
+            match get_default_browser():
                 case "chrome":
                     import selenium.webdriver as webdriver
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -8,6 +8,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def import_browser_module():
+    """Import the browser module fresh for each test."""
+    sys.modules.pop("labapi.browser", None)
+    import labapi.browser
+
+    return labapi.browser
+
+
 @pytest.fixture
 def mock_installed_browsers():
     """Fixture to mock the installed_browsers module."""
@@ -29,13 +37,10 @@ def test_browser_detection_env_var(mock_installed_browsers):
     """Test browser selection based on LA_AUTH_BROWSER environment variable."""
     mock_installed_browsers["do_i_have_installed"].return_value = True
 
-    with patch("os.getenv", return_value="firefox"):
-        # Reload module to trigger detection logic
-        if "labapi.browser" in sys.modules:
-            del sys.modules["labapi.browser"]
-        import labapi.browser
+    browser = import_browser_module()
 
-        assert labapi.browser.default_browser == "firefox"
+    with patch("os.getenv", return_value="firefox"):
+        assert browser.get_default_browser() == "firefox"
 
 
 def test_browser_detection_default_system(mock_installed_browsers):
@@ -44,12 +49,10 @@ def test_browser_detection_default_system(mock_installed_browsers):
         "what_is_the_default_browser"
     ].return_value = "Google Chrome"
 
-    with patch("os.getenv", return_value=""):
-        if "labapi.browser" in sys.modules:
-            del sys.modules["labapi.browser"]
-        import labapi.browser
+    browser = import_browser_module()
 
-        assert labapi.browser.default_browser == "chrome"
+    with patch("os.getenv", return_value=""):
+        assert browser.get_default_browser() == "chrome"
 
 
 def test_browser_detection_fallback_list(mock_installed_browsers):
@@ -59,12 +62,10 @@ def test_browser_detection_fallback_list(mock_installed_browsers):
         {"name": "Firefox Nightly", "path": "/path/to/firefox"}
     ]
 
-    with patch("os.getenv", return_value=""):
-        if "labapi.browser" in sys.modules:
-            del sys.modules["labapi.browser"]
-        import labapi.browser
+    browser = import_browser_module()
 
-        assert labapi.browser.default_browser == "firefox"
+    with patch("os.getenv", return_value=""):
+        assert browser.default_browser == "firefox"
 
 
 def test_browser_detection_terminal_fallback(mock_installed_browsers):
@@ -72,19 +73,24 @@ def test_browser_detection_terminal_fallback(mock_installed_browsers):
     mock_installed_browsers["what_is_the_default_browser"].return_value = None
     mock_installed_browsers["browsers"].return_value = []
 
-    with patch("os.getenv", return_value=""):
-        if "labapi.browser" in sys.modules:
-            del sys.modules["labapi.browser"]
-        import labapi.browser
+    browser = import_browser_module()
 
-        assert labapi.browser.default_browser == "terminal"
+    with patch("os.getenv", return_value=""):
+        assert browser.default_browser == "terminal"
+
+
+def test_browser_detection_import_is_lazy(mock_installed_browsers):
+    """Test import alone does not inspect browsers or environment variables."""
+    import_browser_module()
+
+    mock_installed_browsers["browsers"].assert_not_called()
+    mock_installed_browsers["what_is_the_default_browser"].assert_not_called()
+    mock_installed_browsers["do_i_have_installed"].assert_not_called()
 
 
 def test_browser_detection_import_error():
     """Test fallback to 'terminal' when installed_browsers cannot be imported."""
     with patch.dict("sys.modules", {"installed_browsers": None}):
-        if "labapi.browser" in sys.modules:
-            del sys.modules["labapi.browser"]
-        import labapi.browser
+        browser = import_browser_module()
 
-        assert labapi.browser.default_browser == "terminal"
+        assert browser.default_browser == "terminal"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import importlib
 from datetime import datetime, timedelta
 from os import getenv
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from requests import Response
 
+import labapi.client as client_module
 from labapi import Client, User
 from labapi.exceptions import ApiError
 
@@ -165,6 +167,34 @@ class TestClientUnit:
         client = Client()
         assert client._base_url is not None
         assert client._akid is not None
+
+    def test_client_import_does_not_load_dotenv(self):
+        """Test importing the module does not eagerly load .env values."""
+        mock_dotenv = Mock()
+
+        with patch.dict("sys.modules", {"dotenv": mock_dotenv}):
+            importlib.reload(client_module)
+
+        mock_dotenv.load_dotenv.assert_not_called()
+
+    def test_client_initialization_only_loads_dotenv_when_needed(self, monkeypatch):
+        """Test .env loading happens at Client() construction only for missing params."""
+        mock_dotenv = Mock()
+        monkeypatch.setenv("ACCESS_KEYID", "test_akid")
+        monkeypatch.setenv("ACCESS_PWD", "test_password")
+        monkeypatch.delenv("API_URL", raising=False)
+
+        with patch.dict("sys.modules", {"dotenv": mock_dotenv}):
+            importlib.reload(client_module)
+
+            client_module.Client("https://api.test.com", "explicit_akid", "explicit_pwd")
+            mock_dotenv.load_dotenv.assert_not_called()
+
+            client = client_module.Client()
+
+        mock_dotenv.load_dotenv.assert_called_once()
+        assert client._akid == "test_akid"
+        assert client._base_url == "https://api.labarchives.com"
 
 
 class TestClientIntegration:


### PR DESCRIPTION
## Summary
- move browser detection behind `get_default_browser()` so importing the library no longer probes the environment or installed browsers
- preserve the historical `labapi.browser.default_browser` module attribute via lazy module attribute access
- load `.env` values only during `Client()` construction when configuration is missing, instead of at module import time
- add regression tests covering lazy browser detection and lazy dotenv loading

## Testing
- uv run pytest tests/test_browser.py tests/test_client.py -p no:cacheprovider

Closes #77