### PR TITLE
Avoid folder_download path collisions

### DIFF
--- a/examples/folder_download/folder_download.py
+++ b/examples/folder_download/folder_download.py
@@ -40,10 +40,33 @@ def sanitize_filename(name: str) -> str:
     return name or "untitled"
 
 
-def download_page(page: NotebookPage, output_dir: Path) -> None:
+def get_unique_path(
+    base_dir: Path, name: str, used_paths: set[Path], unique_suffix: str
+) -> Path:
+    """Return a collision-safe path for a sanitized LabArchives name."""
+    sanitized_name = sanitize_filename(name)
+    candidate = base_dir / sanitized_name
+
+    if candidate not in used_paths:
+        used_paths.add(candidate)
+        return candidate
+
+    sanitized_suffix = sanitize_filename(unique_suffix)[:8] or "dup"
+    candidate = base_dir / f"{sanitized_name}_{sanitized_suffix}"
+
+    counter = 1
+    while candidate in used_paths:
+        candidate = base_dir / f"{sanitized_name}_{sanitized_suffix}_{counter}"
+        counter += 1
+
+    used_paths.add(candidate)
+    return candidate
+
+
+def download_page(page: NotebookPage, output_dir: Path, used_paths: set[Path]) -> None:
     """Download a page and its entries to a directory."""
 
-    page_dir = output_dir / sanitize_filename(page.name)
+    page_dir = get_unique_path(output_dir, page.name, used_paths, page.id)
     page_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"  Downloading page: {page.name}")
@@ -112,11 +135,12 @@ def download_page(page: NotebookPage, output_dir: Path) -> None:
                 )
 
 
-def download_directory(directory: AbstractTreeContainer, output_dir: Path) -> None:
+def download_directory(
+    directory: AbstractTreeContainer, output_dir: Path, used_paths: set[Path]
+) -> None:
     """Recursively download a directory and its contents."""
 
-    dir_name = sanitize_filename(directory.name)
-    dir_path = output_dir / dir_name
+    dir_path = get_unique_path(output_dir, directory.name, used_paths, directory.id)
     dir_path.mkdir(parents=True, exist_ok=True)
 
     print(f"Downloading directory: {directory.name}")
@@ -125,10 +149,10 @@ def download_directory(directory: AbstractTreeContainer, output_dir: Path) -> No
     for child in directory.children:
         if child.is_dir():
             # Recursively download subdirectory
-            download_directory(child.as_dir(), dir_path)
+            download_directory(child.as_dir(), dir_path, used_paths)
         else:
             # Download page
-            download_page(child.as_page(), dir_path)
+            download_page(child.as_page(), dir_path, used_paths)
 
 
 def download_notebook_or_folder(
@@ -147,12 +171,14 @@ def download_notebook_or_folder(
         else:
             target = notebook
 
+        used_paths: set[Path] = set()
+
         # Download the target
         if target.is_dir():
-            download_directory(target.as_dir(), output_dir)
+            download_directory(target.as_dir(), output_dir, used_paths)
         else:
             # It's a page
-            download_page(target.as_page(), output_dir)
+            download_page(target.as_page(), output_dir, used_paths)
 
         print(f"\nDownload complete! Content saved to: {output_dir.absolute()}")
 

--- a/tests/examples/test_folder_download.py
+++ b/tests/examples/test_folder_download.py
@@ -1,0 +1,82 @@
+"""Tests for the folder_download example script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def load_folder_download_module():
+    """Load the example script as a module for direct unit testing."""
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "folder_download"
+        / "folder_download.py"
+    )
+    spec = importlib.util.spec_from_file_location("folder_download_example", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+folder_download = load_folder_download_module()
+
+
+class FakePage:
+    """Minimal page double for exercising the download helper."""
+
+    def __init__(self, name: str, page_id: str):
+        self.name = name
+        self.id = page_id
+        self.entries = []
+
+
+def test_get_unique_path_returns_sanitized_name(tmp_path):
+    """Test unique paths preserve the original sanitized name when unused."""
+    used_paths: set[Path] = set()
+
+    path = folder_download.get_unique_path(
+        tmp_path,
+        "Experiment:1",
+        used_paths,
+        "page-one",
+    )
+
+    assert path == tmp_path / "Experiment_1"
+    assert path in used_paths
+
+
+def test_get_unique_path_uses_id_suffix_on_collision(tmp_path):
+    """Test colliding sanitized names are disambiguated with the node id."""
+    used_paths: set[Path] = set()
+
+    first = folder_download.get_unique_path(
+        tmp_path,
+        "Experiment:1",
+        used_paths,
+        "page-one",
+    )
+    second = folder_download.get_unique_path(
+        tmp_path,
+        "Experiment/1",
+        used_paths,
+        "page-two",
+    )
+
+    assert first == tmp_path / "Experiment_1"
+    assert second == tmp_path / "Experiment_1_page-two"
+
+
+def test_download_page_uses_collision_safe_directory_names(tmp_path):
+    """Test page downloads do not merge different names into one directory."""
+    used_paths: set[Path] = set()
+
+    folder_download.download_page(FakePage("Experiment:1", "page-one"), tmp_path, used_paths)
+    folder_download.download_page(FakePage("Experiment/1", "page-two"), tmp_path, used_paths)
+
+    assert (tmp_path / "Experiment_1").is_dir()
+    assert (tmp_path / "Experiment_1_page-two").is_dir()


### PR DESCRIPTION
## Summary
- add a collision-safe path helper to the `folder_download` example so different LabArchives names do not merge into the same local directory
- use node ids as the first disambiguation suffix for sibling page and directory name collisions
- add example-level regression tests covering sanitized path uniqueness and page download directory separation

## Testing
- uv run pytest tests/examples/test_folder_download.py -p no:cacheprovider

Closes #56