### PR TITLE
[codex] fix: support escaped separators in notebook paths

### DIFF
--- a/docs/source/guide/paths.rst
+++ b/docs/source/guide/paths.rst
@@ -67,6 +67,17 @@ Use ``..`` to navigate to the parent container.
     parent = page.traverse("..")
     grandparent = page.traverse("../..")
 
+Escaping Path Separators
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a backslash to keep ``/`` as part of a path segment instead of treating it
+as a separator.
+
+.. code-block:: python
+
+    figure = notebook.traverse(r"Experiments/Figure\/1")
+    page = notebook.page(r"Reports\/2024")
+
 .. note::
    To inspect duplicate child names under a container, use explicit indexing
    on that container (for example, ``container[Index.Name: "Results"]``)
@@ -74,8 +85,8 @@ Use ``..`` to navigate to the parent container.
    (see :ref:`index_access`).
 
 .. warning::
-   Nodes with the literal name ``".."`` cannot be accessed via ``traverse``, as ``..`` is
-   reserved for parent navigation.
+   Nodes with the literal name ``".."`` cannot be accessed via ``traverse``,
+   as ``..`` is reserved for parent navigation.
 
 Enumerating Descendants
 -----------------------

--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -40,6 +40,7 @@ from labapi.util import (
     extract_etree,
     to_bool,
 )
+from labapi.util.path import EscapedSegment
 
 if TYPE_CHECKING:
     from labapi.user import User
@@ -204,7 +205,9 @@ class AbstractBaseTreeNode(ABC, HasNameMixin):
                   at the specified path.
         :raises TraversalError: If traversal cannot continue through a segment.
         """
-        canonical = NotebookPath(path) if isinstance(path, str) else path
+        canonical = (
+            NotebookPath(EscapedSegment(path)) if isinstance(path, str) else path
+        )
         canonical = canonical.resolve(self.path)
 
         curr = self.root
@@ -743,7 +746,9 @@ class AbstractTreeContainer(
                                  ``InsertBehavior.Raise`` and the node already
                                  exists.
         """
-        normalized_name = NotebookPath(name) if isinstance(name, str) else name
+        normalized_name = (
+            NotebookPath(EscapedSegment(name)) if isinstance(name, str) else name
+        )
         path = normalized_name.resolve(self.path).relative_to(self)
 
         if len(path) == 0:
@@ -781,7 +786,7 @@ class AbstractTreeContainer(
             self._children.append(new_node)
             return new_node
         if parents:
-            next_node = self.dir(path[0])
+            next_node = self.dir(*NotebookPath.escape(path[0]))
 
             return next_node.create(
                 cls,

--- a/src/labapi/util/path.py
+++ b/src/labapi/util/path.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, overload
+from enum import Enum
+from typing import TYPE_CHECKING, NamedTuple, overload
 
 from typing_extensions import override
 
@@ -11,6 +12,60 @@ from labapi.exceptions import PathError
 
 if TYPE_CHECKING:
     from labapi.tree.mixins import AbstractBaseTreeNode
+
+
+class _LexerState(Enum):
+    BASE = 1
+    ESCAPE = 2
+
+
+def _lexe(*paths: str) -> tuple[Sequence[str], bool]:
+    segments: list[str] = []
+    segment = ""
+    lexe_state = _LexerState.BASE
+
+    path = "/".join(paths)
+
+    for char in path:
+        match char, lexe_state:
+            case "\\", _LexerState.BASE:
+                lexe_state = _LexerState.ESCAPE
+            case "/", _LexerState.BASE:
+                if len(segment) > 0:
+                    segments.append(segment)
+                    segment = ""
+            case _, _LexerState.BASE:
+                segment += char
+            case _, _LexerState.ESCAPE:
+                segment += char
+                lexe_state = _LexerState.BASE
+    
+    if len(segment):
+        segments.append(segment)
+
+    return segments, path.startswith("/")
+
+
+def _canonicalize(*path: str, from_root: bool) -> Sequence[str]:
+    assert not isinstance(path, str)
+
+    canonical: list[str] = []
+
+    for segment in path:
+        match segment:
+            case ".":
+                continue
+            case ".." if len(canonical) == 0:
+                if not from_root:
+                    canonical.append("..")
+            case ".." if canonical[-1] == "..":
+                canonical.append("..")
+            case "..":
+                canonical.pop()
+            case _:
+                canonical.append(segment)
+
+    return canonical
 
 
 class NotebookPath(Sequence[str]):
@@ -73,18 +128,18 @@ class NotebookPath(Sequence[str]):
         else:
             self._parent = None
 
+        other_parts, _ = _lexe(*parts)
+
         if isinstance(part, NotebookPath):
-            self._parts = NotebookPath._combine(part._parts, parts, part._absolute)
+            self._parts = _canonicalize(*part._parts, *other_parts, from_root=part._absolute)
             self._absolute = part._absolute
             self._parent = part._parent
         elif isinstance(part, str):
-            is_abs = NotebookPath._is_absolute_seq(part) and self._parent is None
-            self._parts = NotebookPath._combine((part,), parts, is_abs)
-            self._absolute = is_abs
+            lexed, is_absolute = _lexe(part)
+            self._absolute = is_absolute and self._parent is None
+            self._parts = _canonicalize(*lexed, *other_parts, from_root=self._absolute)
         else:
-            self._parts = NotebookPath._combine(
-                NotebookPath._of_node(part), parts, True
-            )
+            self._parts = _canonicalize(*NotebookPath._of_node(part), *other_parts, from_root=True)
             self._absolute = True
 
     def __truediv__(self, other: str | NotebookPath) -> NotebookPath:
@@ -310,44 +365,6 @@ class NotebookPath(Sequence[str]):
     def __str__(self) -> str:
         """Return the slash-separated string form of the path."""
         return self.to_string()
-
-    @staticmethod
-    def _is_absolute_seq(a: Sequence[str]) -> bool:
-        """Return ``True`` if the first element of ``a`` starts with ``/``."""
-        return len(a) > 0 and a[0].startswith("/")
-
-    @staticmethod
-    def _combine(a: Sequence[str], b: Sequence[str], from_root: bool) -> Sequence[str]:
-        """Merge two sequences of raw path segments into a normalised list.
-
-        Splits each element on ``/``, strips whitespace, drops empty segments
-        and ``.``, and resolves ``..`` (popping the previous segment, or
-        keeping ``..`` literally at the start of a relative path).
-
-        :param a: First sequence of raw segments (e.g. from an existing path).
-        :param b: Second sequence of raw segments to append.
-        :param from_root: Whether the combined path is rooted (absolute). When
-            ``True``, a leading ``..`` is silently dropped instead of kept.
-        :returns: A flat list of normalised, non-empty segment strings.
-        """
-        canonical: list[str] = []
-
-        # NOTE no support for escapes
-        for segment in [k.strip() for part in [*a, *b] for k in part.split("/")]:
-            match segment:
-                case "." | "":
-                    continue
-                case "..":
-                    if len(canonical) == 0:
-                        if not from_root:
-                            canonical.append("..")
-                    elif canonical[-1] == "..":
-                        canonical.append("..")
-                    else:
-                        canonical.pop()
-                case _:
-                    canonical.append(segment)
-        return canonical
 
     @staticmethod
     def _of_node(a: AbstractBaseTreeNode) -> Sequence[str]:

--- a/src/labapi/util/path.py
+++ b/src/labapi/util/path.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from enum import Enum
-from typing import TYPE_CHECKING, NamedTuple, overload
+from typing import TYPE_CHECKING, overload
 
 from typing_extensions import override
 
@@ -39,7 +39,7 @@ def _lexe(*paths: str) -> tuple[Sequence[str], bool]:
             case _, _LexerState.ESCAPE:
                 segment += char
                 lexe_state = _LexerState.BASE
-    
+
     if len(segment):
         segments.append(segment)
 
@@ -131,7 +131,9 @@ class NotebookPath(Sequence[str]):
         other_parts, _ = _lexe(*parts)
 
         if isinstance(part, NotebookPath):
-            self._parts = _canonicalize(*part._parts, *other_parts, from_root=part._absolute)
+            self._parts = _canonicalize(
+                *part._parts, *other_parts, from_root=part._absolute
+            )
             self._absolute = part._absolute
             self._parent = part._parent
         elif isinstance(part, str):
@@ -139,7 +141,9 @@ class NotebookPath(Sequence[str]):
             self._absolute = is_absolute and self._parent is None
             self._parts = _canonicalize(*lexed, *other_parts, from_root=self._absolute)
         else:
-            self._parts = _canonicalize(*NotebookPath._of_node(part), *other_parts, from_root=True)
+            self._parts = _canonicalize(
+                *NotebookPath._of_node(part), *other_parts, from_root=True
+            )
             self._absolute = True
 
     def __truediv__(self, other: str | NotebookPath) -> NotebookPath:

--- a/src/labapi/util/path.py
+++ b/src/labapi/util/path.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from enum import Enum
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, NewType, overload
 
 from typing_extensions import override
 
@@ -14,13 +14,17 @@ if TYPE_CHECKING:
     from labapi.tree.mixins import AbstractBaseTreeNode
 
 
+EscapedSegment = NewType("EscapedSegment", str)
+UnescapedSegment = NewType("UnescapedSegment", str)
+
+
 class _LexerState(Enum):
     BASE = 1
     ESCAPE = 2
 
 
-def _lexe(*paths: str) -> tuple[Sequence[str], bool]:
-    segments: list[str] = []
+def _lexe(*paths: str) -> tuple[Sequence[UnescapedSegment], bool]:
+    segments: list[UnescapedSegment] = []
     segment = ""
     lexe_state = _LexerState.BASE
 
@@ -32,7 +36,7 @@ def _lexe(*paths: str) -> tuple[Sequence[str], bool]:
                 lexe_state = _LexerState.ESCAPE
             case "/", _LexerState.BASE:
                 if len(segment) > 0:
-                    segments.append(segment)
+                    segments.append(UnescapedSegment(segment))
                     segment = ""
             case _, _LexerState.BASE:
                 segment += char
@@ -40,16 +44,21 @@ def _lexe(*paths: str) -> tuple[Sequence[str], bool]:
                 segment += char
                 lexe_state = _LexerState.BASE
 
+    if lexe_state == _LexerState.ESCAPE:
+        raise PathError("Path cannot end with an escape character", path=path)
+
     if len(segment):
-        segments.append(segment)
+        segments.append(UnescapedSegment(segment))
 
     return segments, path.startswith("/")
 
 
-def _canonicalize(*path: str, from_root: bool) -> Sequence[str]:
+def _canonicalize(
+    *path: UnescapedSegment, from_root: bool
+) -> Sequence[UnescapedSegment]:
     assert not isinstance(path, str)
 
-    canonical: list[str] = []
+    canonical: list[UnescapedSegment] = []
 
     for segment in path:
         match segment:
@@ -57,9 +66,9 @@ def _canonicalize(*path: str, from_root: bool) -> Sequence[str]:
                 continue
             case ".." if len(canonical) == 0:
                 if not from_root:
-                    canonical.append("..")
+                    canonical.append(segment)
             case ".." if canonical[-1] == "..":
-                canonical.append("..")
+                canonical.append(segment)
             case "..":
                 canonical.pop()
             case _:
@@ -68,16 +77,18 @@ def _canonicalize(*path: str, from_root: bool) -> Sequence[str]:
     return canonical
 
 
-class NotebookPath(Sequence[str]):
-    """A structured path referencing a location in the notebook tree.
+class NotebookPath(Sequence[UnescapedSegment]):
+    r"""A structured path referencing a location in the notebook tree.
 
-    Behaves like a sequence of path segments (strings) and supports Unix-style
-    path semantics including absolute/relative paths and ``..`` parent navigation.
+    Supports absolute and relative paths, plus ``..`` parent navigation.
 
-    Paths can be constructed from a tree node, another ``NotebookPath``, or raw
-    slash-separated strings. Segments are normalised on construction: empty
-    segments and ``.`` are discarded, and ``..`` collapses the preceding segment
-    (or is kept literally when at the root of a relative path).
+    Empty segments and ``.`` are discarded; ``..`` collapses the preceding
+    segment, or is kept at the root of a relative path.
+
+    If a node name contains a literal ``/``, write it as ``\/`` in a path
+    string, e.g. ``r"Reports\/2024"``. Iteration, indexing, :attr:`name`, and
+    :attr:`parts` return node names. ``str()`` adds escapes back so the result
+    can be parsed again.
 
     Examples::
 
@@ -94,27 +105,24 @@ class NotebookPath(Sequence[str]):
 
     def __init__(
         self,
-        part: NotebookPath | AbstractBaseTreeNode | str,
-        *parts: str,
+        part: NotebookPath | AbstractBaseTreeNode | EscapedSegment,
+        *parts: EscapedSegment,
         parent: NotebookPath | AbstractBaseTreeNode | None = None,
     ):
-        """Construct a ``NotebookPath``.
+        r"""Construct a ``NotebookPath``.
 
-        The first argument ``part`` sets the base of the path; any additional
-        positional ``parts`` are appended as extra segments.
+        Additional ``parts`` are appended to ``part``.
 
-        :param part: The base of the path. Pass a tree node to create an
-            absolute path rooted at that node's location, a ``NotebookPath``
-            to extend it, or a slash-separated string (absolute strings start
-            with ``/``; others are relative).
-        :param parts: Additional slash-separated path segments appended after
-            ``part``. Segments are split on ``/`` and normalised.
-        :param parent: An absolute path (or node) that anchors a relative
-            string path for later resolution. Must be absolute.
+        :param part: A tree node creates an absolute path, a ``NotebookPath``
+            is copied, and a string is parsed as path syntax.
+        :param parts: Additional path strings appended after ``part``. ``/``
+            separates segments unless it is escaped as ``\/``.
+        :param parent: Absolute path or node used later to resolve a relative
+            string path. Must be absolute.
         :raises PathError: If ``parent`` is not absolute.
         """
         self._parent: NotebookPath | None = None
-        self._parts: Sequence[str] = ()
+        self._parts: Sequence[UnescapedSegment] = ()
         self._absolute: bool = False
 
         if parent is not None:
@@ -157,21 +165,49 @@ class NotebookPath(Sequence[str]):
         :returns: A new ``NotebookPath`` with ``other`` appended or resolved.
         """
         if isinstance(other, str):
-            return NotebookPath(self, other)
+            return NotebookPath(self, EscapedSegment(other))
         return other.resolve(self)
 
-    def to_string(self) -> str:
-        """Return the path as a slash-separated string.
+    @staticmethod
+    def escape(*parts: UnescapedSegment) -> tuple[EscapedSegment, ...]:
+        """Add path escapes."""
+        return tuple(
+            EscapedSegment(part.replace("\\", "\\\\").replace("/", r"\/"))
+            for part in parts
+        )
 
-        Absolute paths are prefixed with ``/``; relative paths are not.
+    @staticmethod
+    def unescape(part: EscapedSegment) -> UnescapedSegment:
+        """Remove path escapes."""
+        segment = ""
+        lexe_state = _LexerState.BASE
 
-        :returns: The string representation of this path (e.g.
-            ``"/Experiments/2024"`` or ``"2024/Results"``).
+        for char in part:
+            match char, lexe_state:
+                case "\\", _LexerState.BASE:
+                    lexe_state = _LexerState.ESCAPE
+                case _, _LexerState.BASE:
+                    segment += char
+                case _, _LexerState.ESCAPE:
+                    segment += char
+                    lexe_state = _LexerState.BASE
+
+        return UnescapedSegment(segment)
+
+    def to_string(self, escape=False) -> str:
+        r"""Return the path as a slash-separated string.
+
+        By default, names are joined as-is. Pass ``escape=True`` to match
+        ``str(path)``.
+
+        :returns: Examples include ``"/Experiments/2024"`` and
+            ``"2024/Results"``.
         """
+        parts = self.escape(*self._parts) if escape else self._parts
         if self._absolute:
-            return f"/{'/'.join(self._parts)}"
+            return f"/{'/'.join(parts)}"
 
-        return "/".join(self._parts)
+        return "/".join(parts)
 
     def is_absolute(self) -> bool:
         """Return whether this path is absolute.
@@ -204,7 +240,8 @@ class NotebookPath(Sequence[str]):
         if self._parent is None:
             if parent is not None:
                 return NotebookPath(
-                    parent.resolve() if recurse else parent, *self._parts
+                    parent.resolve() if recurse else parent,
+                    *self.escape(*self._parts),
                 )
 
             raise PathError(
@@ -212,7 +249,7 @@ class NotebookPath(Sequence[str]):
                 path=str(self),
             )
 
-        return NotebookPath(self._parent, *self._parts)
+        return NotebookPath(self._parent, *self.escape(*self._parts))
 
     def startswith(self, other: NotebookPath) -> bool:
         """Return whether this path starts with another path's segments.
@@ -271,41 +308,35 @@ class NotebookPath(Sequence[str]):
             )
 
         if not other._absolute and other._parent is None:
-            return NotebookPath(*self[len(other) :])
+            return NotebookPath(*self.escape(*self[len(other) :]))
 
         p_origin = other.resolve()
         p_endpoint = self.resolve(other)
 
         remaining = list(p_endpoint[len(p_origin) :])
         return (
-            NotebookPath(*remaining, parent=p_origin)
+            NotebookPath(*self.escape(*remaining), parent=p_origin)
             if remaining
-            else NotebookPath("", parent=p_origin)
+            else NotebookPath(EscapedSegment(""), parent=p_origin)
         )
 
     @property
-    def name(self) -> str:
-        """The final segment of the path.
+    def name(self) -> UnescapedSegment:
+        """The final node name.
 
-        Equivalent to the node's display name when the path was built from a
-        tree node. Returns ``"."`` for an empty path.
-
-        :returns: The last path segment, or ``"."`` if the path is empty.
+        Returns ``"."`` for an empty path.
         """
         if len(self._parts):
             return self._parts[-1]
-        return "."
+        return UnescapedSegment(".")
 
     @property
-    def parts(self) -> Sequence[str]:
-        """All path segments except the last one.
+    def parts(self) -> Sequence[UnescapedSegment]:
+        """All node names except the last one.
 
         Analogous to the parent directory in a file path.
-
-        :returns: A sequence of segment strings, empty if the path has only
-            one segment.
         """
-        return self._parts[:-1]
+        return tuple(self._parts[:-1])
 
     @property
     def parent(self) -> NotebookPath:
@@ -318,8 +349,8 @@ class NotebookPath(Sequence[str]):
         return self.resolve() / ".."
 
     @override
-    def __iter__(self) -> Iterator[str]:
-        """Iterate over the path segments in order."""
+    def __iter__(self) -> Iterator[UnescapedSegment]:
+        """Iterate over node names in order."""
         return iter(self._parts)
 
     @override
@@ -328,14 +359,16 @@ class NotebookPath(Sequence[str]):
         return len(self._parts)
 
     @overload
-    def __getitem__(self, idx: int) -> str: ...
+    def __getitem__(self, idx: int) -> UnescapedSegment: ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[str]: ...
+    def __getitem__(self, idx: slice) -> Sequence[UnescapedSegment]: ...
 
     @override
-    def __getitem__(self, idx: int | slice) -> str | Sequence[str]:
-        """Return the segment at ``idx``, or a sub-sequence for a slice."""
+    def __getitem__(
+        self, idx: int | slice
+    ) -> UnescapedSegment | Sequence[UnescapedSegment]:
+        """Return node name(s)."""
         return self._parts[idx]
 
     @override
@@ -363,15 +396,15 @@ class NotebookPath(Sequence[str]):
     @override
     def __repr__(self) -> str:
         """Return a developer-readable representation, e.g. ``NotebookPath('/a/b')``."""
-        return f"{type(self).__name__}({self.to_string()!r})"
+        return f"{type(self).__name__}({self.to_string(escape=True)!r})"
 
     @override
     def __str__(self) -> str:
-        """Return the slash-separated string form of the path."""
-        return self.to_string()
+        """Return a reusable path string; use ``to_string()`` for raw names."""
+        return self.to_string(escape=True)
 
     @staticmethod
-    def _of_node(a: AbstractBaseTreeNode) -> Sequence[str]:
+    def _of_node(a: AbstractBaseTreeNode) -> Sequence[UnescapedSegment]:
         """Return the ordered list of ancestor names from the notebook root to ``a``.
 
         Walks ``a.parent`` until the root is reached, building the segment list
@@ -381,12 +414,12 @@ class NotebookPath(Sequence[str]):
         :returns: A sequence of name strings representing the path from root to
             ``a``, not including the root notebook itself.
         """
-        stack: list[str] = []
+        stack: list[UnescapedSegment] = []
 
         curr = a
 
         while curr is not curr.root:
-            stack.append(curr.name)
+            stack.append(UnescapedSegment(curr.name))
             curr = curr.parent
 
         return stack[::-1]

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -18,6 +18,7 @@ from labapi.tree.mixins import (
     AbstractTreeContainer,
 )
 from labapi.util import InsertBehavior, NotebookPath
+from labapi.util.path import EscapedSegment
 
 
 def expect_dir(node: object) -> NotebookDirectory:
@@ -50,6 +51,29 @@ class TestTreeMixinsIntegration:
         page_a = notebook_tree.traverse("/Test Folder A/Dir1 Test Page A")
         assert page_a.name == "Dir1 Test Page A"
         assert page_a.id == "page-1-1"
+
+    def test_traverse_escaped_separator_in_node_names(self, notebook_tree: Notebook):
+        """Test traversing to nodes whose names contain literal slashes."""
+        slash_dir = NotebookDirectory(
+            "slash-dir",
+            "Reports/2024",
+            notebook_tree,
+            notebook_tree,
+            notebook_tree.user,
+        )
+        slash_page = NotebookPage(
+            "slash-page",
+            "Summary/Final",
+            notebook_tree,
+            slash_dir,
+            notebook_tree.user,
+        )
+        slash_dir._children.append(slash_page)  # pyright: ignore[reportPrivateUsage]
+        slash_dir._populated = True  # pyright: ignore[reportPrivateUsage]
+        notebook_tree._children.append(slash_dir)  # pyright: ignore[reportPrivateUsage]
+
+        assert notebook_tree.traverse(r"/Reports\/2024/Summary\/Final") is slash_page
+        assert slash_dir.traverse(r"Summary\/Final") is slash_page
 
     def test_traverse_parent(self, notebook_tree: Notebook):
         """Test traversing with '..'."""
@@ -474,6 +498,47 @@ class TestTreeMixinsIntegration:
         assert api_call[1]["display_text"] == "New Folder"
         assert api_call[1]["is_folder"] == "true"
 
+    def test_create_escaped_separator_as_literal_child_name(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test creating a direct child whose name contains a literal slash."""
+        client.api_response = client.tree_node_response("slash-page-id")
+
+        new_page = notebook_tree.create(NotebookPage, r"Reports\/2024")
+
+        assert isinstance(new_page, NotebookPage)
+        assert new_page.name == "Reports/2024"
+        assert new_page.parent is notebook_tree
+
+        api_call = client.pop_api_call()
+        assert api_call[0] == "tree_tools/insert_node"
+        assert api_call[1]["display_text"] == "Reports/2024"
+        assert api_call[1]["is_folder"] == "false"
+
+    def test_page_creates_parents_with_escaped_separator_segments(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test parent creation preserves literal slashes in path segments."""
+        client.api_response = client.tree_node_response("slash-dir-id")
+        client.api_response = client.tree_node_response("slash-page-id")
+
+        new_page = notebook_tree.page(r"Reports\/2024/Summary\/Final")
+
+        assert isinstance(new_page, NotebookPage)
+        assert new_page.name == "Summary/Final"
+        assert new_page.parent.name == "Reports/2024"
+        assert new_page.parent.parent is notebook_tree
+
+        dir_call = client.pop_api_call()
+        assert dir_call[0] == "tree_tools/insert_node"
+        assert dir_call[1]["display_text"] == "Reports/2024"
+        assert dir_call[1]["is_folder"] == "true"
+
+        page_call = client.pop_api_call()
+        assert page_call[0] == "tree_tools/insert_node"
+        assert page_call[1]["display_text"] == "Summary/Final"
+        assert page_call[1]["is_folder"] == "false"
+
     def test_create_page_subclass_uses_page_semantics(
         self, client, notebook_tree: Notebook
     ):
@@ -597,7 +662,8 @@ class TestTreeMixinsIntegration:
         client.api_response = client.tree_node_response("absolute-dir-id")
 
         new_dir = folder_a.create(
-            NotebookDirectory, NotebookPath("/Test Folder A/Absolute String Dir")
+            NotebookDirectory,
+            NotebookPath(EscapedSegment("/Test Folder A/Absolute String Dir")),
         )
 
         assert isinstance(new_dir, NotebookDirectory)

--- a/tests/util/test_path.py
+++ b/tests/util/test_path.py
@@ -33,6 +33,30 @@ def test_notebook_path_normalization():
     assert str(path) == "/Experiments/2024"
 
 
+def test_notebook_path_escaped_slash_is_literal_segment_character():
+    """Test escaped slashes do not split path segments."""
+    path = NotebookPath(r"/Experiments/Figure\/1")
+
+    assert path.is_absolute() is True
+    assert list(path) == ["Experiments", "Figure/1"]
+    assert path.name == "Figure/1"
+
+
+def test_notebook_path_escaped_segments_with_multiple_parts():
+    """Test escaped slashes work across appended path parts."""
+    path = NotebookPath(r"Folder\/Name", r"Page\/Name")
+
+    assert path.is_absolute() is False
+    assert list(path) == ["Folder/Name", "Page/Name"]
+
+
+def test_notebook_path_div_operator_accepts_escaped_slashes():
+    """Test path appending keeps escaped slashes inside a single segment."""
+    path = NotebookPath("/Experiments") / r"Figure\/1"
+
+    assert list(path) == ["Experiments", "Figure/1"]
+
+
 def test_notebook_path_from_node():
     """Test NotebookPath creation from a tree node."""
     mock_root = Mock()

--- a/tests/util/test_path.py
+++ b/tests/util/test_path.py
@@ -7,12 +7,12 @@ from unittest.mock import Mock
 import pytest
 
 from labapi.exceptions import PathError
-from labapi.util.path import NotebookPath
+from labapi.util.path import EscapedSegment, NotebookPath, UnescapedSegment
 
 
 def test_notebook_path_from_string_absolute():
     """Test NotebookPath creation from an absolute path string."""
-    path = NotebookPath("/Experiments/2024")
+    path = NotebookPath(EscapedSegment("/Experiments/2024"))
     assert path.is_absolute() is True
     assert list(path) == ["Experiments", "2024"]
     assert str(path) == "/Experiments/2024"
@@ -20,7 +20,7 @@ def test_notebook_path_from_string_absolute():
 
 def test_notebook_path_from_string_relative():
     """Test NotebookPath creation from a relative path string."""
-    path = NotebookPath("2024/Results")
+    path = NotebookPath(EscapedSegment("2024/Results"))
     assert path.is_absolute() is False
     assert list(path) == ["2024", "Results"]
     assert str(path) == "2024/Results"
@@ -28,23 +28,26 @@ def test_notebook_path_from_string_relative():
 
 def test_notebook_path_normalization():
     """Test path normalization (dots and empty segments)."""
-    path = NotebookPath("//Experiments/./2024//Results/../")
+    path = NotebookPath(EscapedSegment("//Experiments/./2024//Results/../"))
     assert list(path) == ["Experiments", "2024"]
     assert str(path) == "/Experiments/2024"
 
 
 def test_notebook_path_escaped_slash_is_literal_segment_character():
     """Test escaped slashes do not split path segments."""
-    path = NotebookPath(r"/Experiments/Figure\/1")
+    path = NotebookPath(EscapedSegment(r"/Experiments/Figure\/1"))
 
     assert path.is_absolute() is True
     assert list(path) == ["Experiments", "Figure/1"]
     assert path.name == "Figure/1"
+    assert path.to_string() == "/Experiments/Figure/1"
+    assert path.to_string(escape=True) == r"/Experiments/Figure\/1"
+    assert str(path) == r"/Experiments/Figure\/1"
 
 
 def test_notebook_path_escaped_segments_with_multiple_parts():
     """Test escaped slashes work across appended path parts."""
-    path = NotebookPath(r"Folder\/Name", r"Page\/Name")
+    path = NotebookPath(EscapedSegment(r"Folder\/Name"), EscapedSegment(r"Page\/Name"))
 
     assert path.is_absolute() is False
     assert list(path) == ["Folder/Name", "Page/Name"]
@@ -52,9 +55,163 @@ def test_notebook_path_escaped_segments_with_multiple_parts():
 
 def test_notebook_path_div_operator_accepts_escaped_slashes():
     """Test path appending keeps escaped slashes inside a single segment."""
-    path = NotebookPath("/Experiments") / r"Figure\/1"
+    path = NotebookPath(EscapedSegment("/Experiments")) / r"Figure\/1"
 
     assert list(path) == ["Experiments", "Figure/1"]
+    assert path.to_string() == "/Experiments/Figure/1"
+    assert path.to_string(escape=True) == r"/Experiments/Figure\/1"
+    assert str(path) == r"/Experiments/Figure\/1"
+
+
+def test_notebook_path_escape_unescape_segment():
+    """Test escaping and unescaping literal segment values."""
+    part = UnescapedSegment("Folder\\Name/Figure")
+
+    escaped = NotebookPath.escape(part)
+
+    assert escaped == (r"Folder\\Name\/Figure",)
+    assert NotebookPath.unescape(escaped[0]) == part
+    assert NotebookPath.escape(
+        UnescapedSegment("Folder/Name"), UnescapedSegment("Page\\Name")
+    ) == (
+        r"Folder\/Name",
+        r"Page\\Name",
+    )
+
+
+@pytest.mark.parametrize(
+    ("parts", "escaped"),
+    [
+        ((), ()),
+        (("",), ("",)),
+        (("Folder/Name",), (r"Folder\/Name",)),
+        (("Folder\\Name",), (r"Folder\\Name",)),
+        (
+            ("Folder\\Name/Figure", "Page/Name"),
+            (r"Folder\\Name\/Figure", r"Page\/Name"),
+        ),
+    ],
+)
+def test_notebook_path_escape_returns_tuple_and_round_trips(
+    parts: tuple[str, ...], escaped: tuple[str, ...]
+):
+    """Test escaping multiple parsed segments is stable and reversible."""
+    typed_parts = tuple(UnescapedSegment(part) for part in parts)
+    typed_escaped = tuple(EscapedSegment(part) for part in escaped)
+
+    assert NotebookPath.escape(*typed_parts) == escaped
+    assert tuple(NotebookPath.unescape(part) for part in typed_escaped) == parts
+
+
+def test_notebook_path_escaped_slash_round_trips_through_string():
+    """Test string paths preserve escapes needed to parse them again."""
+    path = NotebookPath(EscapedSegment(r"/Experiments/Figure\/1"))
+
+    reparsed = NotebookPath(EscapedSegment(str(path)))
+
+    assert path.to_string() == "/Experiments/Figure/1"
+    assert path.to_string(escape=True) == str(path)
+    assert reparsed == path
+    assert list(reparsed) == ["Experiments", "Figure/1"]
+
+
+def test_notebook_path_escaped_backslash_round_trips_through_string():
+    """Test literal backslashes remain escaped in string paths."""
+    path = NotebookPath(EscapedSegment(r"/Folder\\Name/Page\\Name"))
+
+    reparsed = NotebookPath(EscapedSegment(str(path)))
+
+    assert path.to_string() == "/Folder\\Name/Page\\Name"
+    assert path.to_string(escape=True) == r"/Folder\\Name/Page\\Name"
+    assert str(path) == r"/Folder\\Name/Page\\Name"
+    assert reparsed == path
+    assert list(reparsed) == ["Folder\\Name", "Page\\Name"]
+
+
+def test_notebook_path_rejects_trailing_escape_character():
+    """Test paths cannot end while escaping the next character."""
+    with pytest.raises(PathError, match="Path cannot end with an escape character"):
+        NotebookPath(EscapedSegment("Folder\\"))
+
+
+def test_notebook_path_resolve_preserves_escaped_segments():
+    """Test resolving a relative path keeps parsed slash-containing segments."""
+    parent = NotebookPath(EscapedSegment(r"/Reports\/2024"))
+    path = NotebookPath(EscapedSegment(r"Summary\/Final"), parent=parent)
+
+    resolved = path.resolve()
+
+    assert resolved.is_absolute() is True
+    assert list(resolved) == ["Reports/2024", "Summary/Final"]
+    assert str(resolved) == r"/Reports\/2024/Summary\/Final"
+
+
+def test_notebook_path_resolve_parent_argument_preserves_escaped_segments():
+    """Test resolving against an explicit parent does not split parsed segments."""
+    parent = NotebookPath(EscapedSegment(r"/Reports\/2024"))
+    path = NotebookPath(EscapedSegment(r"Summary\/Final"))
+
+    resolved = path.resolve(parent)
+
+    assert resolved.is_absolute() is True
+    assert list(resolved) == ["Reports/2024", "Summary/Final"]
+    assert str(resolved) == r"/Reports\/2024/Summary\/Final"
+
+
+def test_notebook_path_resolve_recursive_parent_preserves_escaped_segments():
+    """Test recursive parent resolution preserves escaped segments."""
+    root = NotebookPath(EscapedSegment(r"/Archive\/Root"))
+    parent = NotebookPath(EscapedSegment(r"Reports\/2024"), parent=root)
+    path = NotebookPath(EscapedSegment(r"Summary\/Final"))
+
+    resolved = path.resolve(parent, recurse=True)
+
+    assert resolved.is_absolute() is True
+    assert list(resolved) == ["Archive/Root", "Reports/2024", "Summary/Final"]
+    assert str(resolved) == r"/Archive\/Root/Reports\/2024/Summary\/Final"
+
+
+def test_notebook_path_relative_to_preserves_escaped_segments():
+    """Test relative paths do not split already-parsed slash-containing segments."""
+    path = NotebookPath(EscapedSegment(r"/Reports\/2024/Summary\/Final"))
+    parent = NotebookPath(EscapedSegment(r"/Reports\/2024"))
+
+    relative = path.relative_to(parent)
+
+    assert relative.is_absolute() is False
+    assert list(relative) == ["Summary/Final"]
+    assert str(relative) == r"Summary\/Final"
+    assert relative.resolve(parent) == path
+
+
+def test_notebook_path_relative_to_relative_prefix_preserves_escaped_segments():
+    """Test relative_to preserves segments when both paths are relative."""
+    path = NotebookPath(EscapedSegment(r"Reports\/2024/Summary\/Final"))
+    parent = NotebookPath(EscapedSegment(r"Reports\/2024"))
+
+    relative = path.relative_to(parent)
+
+    assert relative.is_absolute() is False
+    assert list(relative) == ["Summary/Final"]
+    assert str(relative) == r"Summary\/Final"
+
+
+def test_notebook_path_normalization_with_escaped_slashes():
+    """Test parent navigation treats escaped slash segments as one segment."""
+    path = NotebookPath(EscapedSegment(r"/Experiments/Figure\/1/../Summary\/Final"))
+
+    assert list(path) == ["Experiments", "Summary/Final"]
+    assert str(path) == r"/Experiments/Summary\/Final"
+
+
+def test_notebook_path_parent_preserves_escaped_segments():
+    """Test parent path output keeps literal separator characters escaped."""
+    path = NotebookPath(EscapedSegment(r"/Reports\/2024/Summary\/Final"))
+
+    parent = path.parent
+
+    assert list(parent) == ["Reports/2024"]
+    assert str(parent) == r"/Reports\/2024"
 
 
 def test_notebook_path_from_node():
@@ -79,28 +236,50 @@ def test_notebook_path_from_node():
     assert str(path) == "/Experiments/2024"
 
 
+def test_notebook_path_from_node_escapes_separator_characters():
+    """Test node-derived paths escape literal slash and backslash characters."""
+    mock_root = Mock()
+    mock_root.root = mock_root
+    mock_root.name = "Root"
+
+    mock_folder = Mock()
+    mock_folder.root = mock_root
+    mock_folder.parent = mock_root
+    mock_folder.name = "Reports/2024"
+
+    mock_page = Mock()
+    mock_page.root = mock_root
+    mock_page.parent = mock_folder
+    mock_page.name = "Summary\\Final"
+
+    path = NotebookPath(mock_page)
+
+    assert list(path) == ["Reports/2024", "Summary\\Final"]
+    assert str(path) == r"/Reports\/2024/Summary\\Final"
+
+
 def test_notebook_path_div_operator():
     """Test the / operator for appending segments and paths."""
-    base = NotebookPath("/Experiments")
+    base = NotebookPath(EscapedSegment("/Experiments"))
     path = base / "2024" / "Results"
 
     assert str(path) == "/Experiments/2024/Results"
 
     # Append relative path
-    rel = NotebookPath("Sub/Folder")
+    rel = NotebookPath(EscapedSegment("Sub/Folder"))
     combined = path / rel
     assert str(combined) == "/Experiments/2024/Results/Sub/Folder"
 
     # Append absolute path returns the absolute path
-    abs_path = NotebookPath("/Other/Root")
+    abs_path = NotebookPath(EscapedSegment("/Other/Root"))
     result = path / abs_path
     assert str(result) == "/Other/Root"
 
 
 def test_notebook_path_resolve_relative():
     """Test resolving a relative path against an absolute parent."""
-    rel = NotebookPath("2024/Results")
-    parent = NotebookPath("/Experiments")
+    rel = NotebookPath(EscapedSegment("2024/Results"))
+    parent = NotebookPath(EscapedSegment("/Experiments"))
 
     resolved = rel.resolve(parent)
     assert resolved.is_absolute() is True
@@ -109,7 +288,7 @@ def test_notebook_path_resolve_relative():
 
 def test_notebook_path_resolve_no_parent_raises():
     """Test resolve raises PathError when no parent is available."""
-    rel = NotebookPath("relative/path")
+    rel = NotebookPath(EscapedSegment("relative/path"))
     with pytest.raises(
         PathError, match="Cannot resolve relative path without an absolute parent"
     ) as err:
@@ -119,8 +298,8 @@ def test_notebook_path_resolve_no_parent_raises():
 
 def test_notebook_path_relative_to_success():
     """Test making a path relative to another."""
-    path = NotebookPath("/Experiments/2024/Results")
-    base = NotebookPath("/Experiments")
+    path = NotebookPath(EscapedSegment("/Experiments/2024/Results"))
+    base = NotebookPath(EscapedSegment("/Experiments"))
 
     rel = path.relative_to(base)
     assert rel.is_absolute() is False
@@ -129,8 +308,8 @@ def test_notebook_path_relative_to_success():
 
 def test_notebook_path_relative_to_failure():
     """Test relative_to raises PathError if path is outside base."""
-    path = NotebookPath("/Experiments/2024")
-    other = NotebookPath("/Analysis")
+    path = NotebookPath(EscapedSegment("/Experiments/2024"))
+    other = NotebookPath(EscapedSegment("/Analysis"))
 
     with pytest.raises(PathError, match="is outside of") as err:
         path.relative_to(other)
@@ -140,7 +319,7 @@ def test_notebook_path_relative_to_failure():
 
 def test_notebook_path_properties():
     """Test name, parts, and parent properties."""
-    path = NotebookPath("/Experiments/2024/Results")
+    path = NotebookPath(EscapedSegment("/Experiments/2024/Results"))
 
     assert path.name == "Results"
     assert list(path.parts) == ["Experiments", "2024"]
@@ -149,9 +328,9 @@ def test_notebook_path_properties():
 
 def test_notebook_path_equality():
     """Test equality and hashing of NotebookPath."""
-    p1 = NotebookPath("/A/B/C")
-    p2 = NotebookPath("/A/B/C")
-    p3 = NotebookPath("A/B/C")
+    p1 = NotebookPath(EscapedSegment("/A/B/C"))
+    p2 = NotebookPath(EscapedSegment("/A/B/C"))
+    p3 = NotebookPath(EscapedSegment("A/B/C"))
 
     assert p1 == p2
     assert p1 != p3
@@ -161,7 +340,7 @@ def test_notebook_path_equality():
 
 def test_notebook_path_empty():
     """Test empty path behavior."""
-    path = NotebookPath("")
+    path = NotebookPath(EscapedSegment(""))
     assert list(path) == []
     assert path.name == "."
     assert str(path) == ""


### PR DESCRIPTION
## Summary

Adds lexer-based notebook path parsing so escaped slashes are treated as literal characters inside path segments instead of separators. This keeps existing normalization semantics for empty segments, . segments, and .. parent traversal while allowing paths like Reports\/2024 to refer to a single node name.

Updates the path guide to document escaping / in node names while keeping the .. parent-navigation limitation documented.

## Validation

- `python -m pytest --no-cov -p no:cacheprovider tests\util\test_path.py`