### PR TITLE
[codex] Refactor JSON sync example into reusable CLI

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -55,16 +55,17 @@ All published examples assume:
 - Python 3.10+.
 - The recommended local interactive profile:
   ``labapi[dotenv,builtin-auth]``.
-- A repository-root working directory when you run ``uv run ...`` commands.
+- A repository-root working directory when you run the ``uv run --project ...``
+  commands below.
 - Notebook-relative page paths paired with ``--notebook "My Notebook"``.
 
 Use these sample commands as known-good starting points:
 
 .. code-block:: bash
 
-   uv run python examples/json_sync/json_sync.py upload examples/json_sync/sample_data "Experiments/2024/Data Analysis" --notebook "My Notebook"
-   uv run python examples/folder_download/folder_download.py ./backup --notebook "My Notebook" --path "Experiments/2024"
-   uv run --with beautifulsoup4 python examples/csv_table/csv_table.py upload examples/csv_table/sample_data.csv "Experiments/Results" --notebook "My Notebook"
+   uv run --project examples/json_sync python examples/json_sync/json_sync.py upload examples/json_sync/sample_data "Experiments/2024/Data Analysis" --notebook "My Notebook"
+   uv run --project examples/folder_download python examples/folder_download/folder_download.py ./backup --notebook "My Notebook" --path "Experiments/2024"
+   uv run --project examples/csv_table python examples/csv_table/csv_table.py upload examples/csv_table/sample_data.csv "Experiments/Results" --notebook "My Notebook"
 
 Additional Local Examples
 -------------------------

--- a/docs/source/examples/json_sync.rst
+++ b/docs/source/examples/json_sync.rst
@@ -47,28 +47,57 @@ Upload the sample JSON files included in the repository:
 
 .. code-block:: bash
 
-   uv run python examples/json_sync/json_sync.py upload examples/json_sync/sample_data "Experiments/2024/Data Analysis" --notebook "My Notebook"
+   uv run --project examples/json_sync python examples/json_sync/json_sync.py upload examples/json_sync/sample_data "Experiments/2024/Data Analysis" --notebook "My Notebook"
 
 Download JSON entries from a page into a local folder:
 
 .. code-block:: bash
 
-   uv run python examples/json_sync/json_sync.py download "Experiments/2024/Data Analysis" ./output --notebook "My Notebook"
+   uv run --project examples/json_sync python examples/json_sync/json_sync.py download "Experiments/2024/Data Analysis" ./output --notebook "My Notebook"
 
 How It Works
 ------------
 
 - JSON files are uploaded with
   :meth:`~labapi.entry.collection.Entries.create_json_entry`.
+- ``examples/json_sync/json_sync.py`` contains importable upload and download
+  functions plus a command-line ``main()`` guarded by the usual
+  ``if __name__ == "__main__"`` check.
 - Each upload creates a JSON attachment with ``application/json`` MIME type and
   a companion rich-text preview entry.
 - Download mode writes each JSON attachment back to a local ``.json`` file.
+
+Reusable API
+------------
+
+When building your own script, import the sync function and call it directly:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from labapi import Client
+   from examples.json_sync.json_sync import upload_json_files
+
+   with Client() as client:
+       user = client.default_authenticate()
+       results = upload_json_files(
+           user,
+           notebook="My Notebook",
+           page="Experiments/2024/Data Analysis",
+           folder=Path("examples/json_sync/sample_data"),
+       )
+
+   uploaded = sum(result.success for result in results)
+   print(f"Uploaded {uploaded}/{len(results)} JSON files")
 
 Notes and Limitations
 ---------------------
 
 - Invalid JSON files are skipped with an error message.
 - The script creates the output folder if it does not exist during download.
+- The reusable functions return a ``FileResult`` for each file they try to sync.
+- The CLI handles terminal output and process exit codes.
 - The sample upload command uses the checked-in files under
   ``examples/json_sync/sample_data``.
 

--- a/examples/json_sync/README.md
+++ b/examples/json_sync/README.md
@@ -1,23 +1,23 @@
 # JSON Folder Sync Example
 
-This example demonstrates how to synchronize JSON files between a local directory and a LabArchives page. It can upload all JSON files from a local folder to LabArchives as JSON entries, or download JSON entries from LabArchives to local JSON files.
+This example synchronizes JSON files between a local directory and a LabArchives page. Use it to upload a folder of local JSON files as LabArchives JSON entries, or to download JSON entries from LabArchives into local `.json` files.
+
+`json_sync.py` contains reusable, typed upload and download functions plus a small command-line interface.
 
 ## Dependencies
 
-This example requires the following packages:
+Install the example with the local authentication helpers:
 
 - `labapi[dotenv,builtin-auth]` (the core library plus local auth helpers)
-
-You can install the dependencies using:
 
 Run these commands from the repository root.
 
 ```bash
+# Using uv (recommended)
+uv sync --project examples/json_sync
+
 # Using pip
 pip install -e ".[dotenv,builtin-auth]"
-
-# Using uv (recommended)
-uv sync
 ```
 
 ## Usage
@@ -25,31 +25,56 @@ uv sync
 ### Upload all JSON files from local folder to LabArchives page
 
 ```bash
-# General usage
-python json_sync.py upload /path/to/json/folder "Data/Results" --notebook "My Notebook"
+# General usage from the repository root
+uv run --project examples/json_sync python examples/json_sync/json_sync.py upload /path/to/json/folder "Data/Results" --notebook "My Notebook"
 
-# Quick test with sample data from project root
-uv run python examples/json_sync/json_sync.py upload examples/json_sync/sample_data "Experiments/JSON Data" --notebook "My Notebook"
+# Quick test with sample data
+uv run --project examples/json_sync python examples/json_sync/json_sync.py upload examples/json_sync/sample_data "Experiments/JSON Data" --notebook "My Notebook"
 ```
 
 ### Download all JSON entries from LabArchives page to local folder
 
 ```bash
-# General usage
-python json_sync.py download "Data/Results" /path/to/output/folder --notebook "My Notebook"
+# General usage from the repository root
+uv run --project examples/json_sync python examples/json_sync/json_sync.py download "Data/Results" /path/to/output/folder --notebook "My Notebook"
 
-# Quick test from project root
-uv run python examples/json_sync/json_sync.py download "Experiments/JSON Data" ./downloaded_json --notebook "My Notebook"
+# Quick test
+uv run --project examples/json_sync python examples/json_sync/json_sync.py download "Experiments/JSON Data" ./downloaded_json --notebook "My Notebook"
 ```
 
 ## Options
 
 - `--notebook`, `-n`: (Required) Name of the LabArchives notebook.
 
+## Reusing the Sync Logic
+
+Import the sync function when you want to compose the workflow from another script:
+
+```python
+from pathlib import Path
+
+from labapi import Client
+from examples.json_sync.json_sync import upload_json_files
+
+with Client() as client:
+    user = client.default_authenticate()
+    results = upload_json_files(
+        user,
+        notebook="My Notebook",
+        page="Experiments/JSON Data",
+        folder=Path("examples/json_sync/sample_data"),
+    )
+
+uploaded = sum(result.success for result in results)
+print(f"Uploaded {uploaded}/{len(results)} JSON files")
+```
+
+The reusable functions return one `FileResult` for each file they try to sync.
+
 ## Configuration
 
-Requires a `.env` file in the project root with your LabArchives credentials.
-The `.env` file is only auto-loaded when the `dotenv` extra is installed:
+Create a `.env` file in the project root with your LabArchives credentials.
+With the `dotenv` extra installed, `labapi` loads this file automatically:
 
 ```env
 ACCESS_KEYID=your_access_key_id

--- a/examples/json_sync/json_sync.py
+++ b/examples/json_sync/json_sync.py
@@ -1,180 +1,194 @@
 #!/usr/bin/env python3
-"""Synchronize JSON files between local disk and a LabArchives page."""
+"""Sync JSON files between local disk and a LabArchives page.
+
+This example has two layers:
+
+* ``upload_json_files`` and ``download_json_files`` are reusable functions. They
+  take an authenticated :class:`labapi.User` and return structured results
+  instead of printing or exiting.
+* ``main`` is the command-line layer. It handles arguments, authentication,
+  terminal output, and process exit codes.
+
+For a first LabArchives API script, the important object chain is:
+
+``Client()`` -> ``client.default_authenticate()`` -> ``User`` ->
+``user.notebooks["Notebook Name"]`` -> ``page.entries``.
+
+The ``User`` object represents the authenticated LabArchives account. A
+notebook is a tree-like container of folders and pages. A page contains entries,
+including attachment entries. JSON entries created by ``labapi`` are stored as
+attachment entries, with an optional text preview beside them.
+"""
+
+from __future__ import annotations
 
 import argparse
 import json
 import sys
-from pathlib import Path
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import cast
 
 from labapi import (
-    AbstractTreeContainer,
     AttachmentEntry,
     Client,
-    InsertBehavior,
-    NotebookPage,
-    TraversalError,
+    JsonData,
     User,
 )
 
 
-def get_or_create_page(container: AbstractTreeContainer, path: str) -> NotebookPage:
-    """Return an existing page at ``path`` or create it with missing parents."""
-    try:
-        node = container.traverse(path)
-    except TraversalError as err:
-        if err.available_children is None:
-            raise
-        return container.create(
-            NotebookPage,
-            path,
-            parents=True,
-            if_exists=InsertBehavior.Retain,
-        )
+@dataclass(frozen=True, slots=True)
+class FileResult:
+    """Outcome for one local or remote JSON file.
 
-    if node.is_dir():
-        raise TypeError(f"'{path}' refers to a directory, but a page is required")
+    ``success`` lets callers decide whether to continue, retry, or fail the
+    surrounding workflow. The CLI below prints a short summary, while imported
+    code can inspect these results directly.
+    """
 
-    return node.as_page()
+    name: str
+    path: Path
+    success: bool
+    error: str | None = None
 
 
-def upload_json_folder(
-    user: User, notebook_name: str, page_path: str, local_folder: Path
-) -> None:
-    """Upload all JSON files from a local folder to a LabArchives page."""
-    if not local_folder.exists():
-        print(f"Error: Local folder '{local_folder}' does not exist")
-        sys.exit(1)
+def upload_json_files(
+    user: User,
+    notebook: str,
+    page: str,
+    folder: Path,
+) -> list[FileResult]:
+    """Upload every ``*.json`` file in ``folder`` to a LabArchives page.
 
-    if not local_folder.is_dir():
-        print(f"Error: '{local_folder}' is not a directory")
-        sys.exit(1)
+    ``user`` is already authenticated, so this function does not know anything
+    about credentials or command-line arguments. It only performs the sync work.
 
-    # Get the target page
-    notebooks = user.notebooks
-    try:
-        notebook = notebooks[notebook_name]
-        print(f"Ensuring page path exists: {page_path}")
-        page = get_or_create_page(notebook, page_path)
-    except (KeyError, TraversalError, TypeError, ValueError) as e:
-        print(f"Error: Could not access or create path '{page_path}': {e}")
-        sys.exit(1)
+    ``notebook`` is the visible notebook name in LabArchives. ``page`` is a
+    LabArchives page path inside that notebook, such as ``"Data/Results"``.
+    ``folder`` is a local filesystem path.
 
-    # Find all JSON files
-    json_files = sorted(local_folder.glob("*.json"))
+    The target page is created if it does not already exist. Each valid JSON
+    file becomes a LabArchives JSON entry through
+    :meth:`labapi.entry.collection.Entries.create_json_entry`.
+    """
+    if not folder.is_dir():
+        raise NotADirectoryError(folder)
 
-    if not json_files:
-        print(f"No JSON files found in '{local_folder}'")
-        return
+    file_paths = sorted(folder.glob("*.json"))
+    if not file_paths:
+        return []
 
-    print(f"Found {len(json_files)} JSON file(s) to upload")
+    # ``page`` is a convenience method from labapi. It ensures the page path
+    # exists, creating any missing parent folders along the way.
+    target_page = user.notebooks[notebook].page(page)
+    results: list[FileResult] = []
 
-    # Upload each JSON file
-    for json_file in json_files:
-        print(f"Uploading {json_file.name}...", end=" ")
-
+    for file_path in file_paths:
         try:
-            with json_file.open("r", encoding="utf-8") as f:
-                data = json.load(f)
+            with file_path.open("r", encoding="utf-8") as file:
+                data = cast(JsonData, json.load(file))
+            # ``create_json_entry`` uploads the JSON as an attachment and
+            # creates the companion preview entry used by LabArchives.
+            target_page.entries.create_json_entry(
+                data,
+                filename=file_path.name,
+                caption=file_path.stem,
+            )
+        except json.JSONDecodeError as exc:
+            results.append(
+                FileResult(file_path.name, file_path, False, f"Invalid JSON: {exc}")
+            )
+        except Exception as exc:
+            results.append(FileResult(file_path.name, file_path, False, str(exc)))
+        else:
+            results.append(FileResult(file_path.name, file_path, True))
 
-            # Create JSON entry
-            page.entries.create_json_entry(data)
-
-            print("✓")
-        except json.JSONDecodeError as e:
-            print(f"✗ (Invalid JSON: {e})")
-        except Exception as e:
-            print(f"✗ (Error: {e})")
-
-    print(f"\nUpload complete! {len(json_files)} files processed.")
+    return results
 
 
-def download_json_entries(
-    user: User, notebook_name: str, page_path: str, local_folder: Path
-) -> None:
-    """Download all JSON entries from a LabArchives page to local files."""
-    # Create output folder if it doesn't exist
-    local_folder.mkdir(parents=True, exist_ok=True)
+def download_json_files(
+    user: User,
+    notebook: str,
+    page: str,
+    folder: Path,
+) -> list[FileResult]:
+    """Download JSON attachment entries from a LabArchives page into ``folder``.
 
-    # Get the source page
-    notebooks = user.notebooks
-    try:
-        notebook = notebooks[notebook_name]
-    except KeyError as e:
-        print(f"Error: Could not find notebook '{notebook_name}': {e}")
-        print(f"Available notebooks: {list(notebooks.keys())}")
-        sys.exit(1)
-    try:
-        page = notebook.traverse(page_path).as_page()
-    except TraversalError as e:
-        print(
-            f"Error: Could not find page '{page_path}' in notebook '{notebook_name}': {e}"
-        )
-        sys.exit(1)
-    except TypeError:
-        print(f"Error: '{page_path}' refers to a directory, but a page is required")
-        sys.exit(1)
+    Download is intentionally read-only for LabArchives. It traverses to an
+    existing page, inspects that page's entries, and writes JSON attachments to
+    local files.
 
-    # Find all JSON entries
-    entries = page.entries
-    json_entries: list[AttachmentEntry] = []
+    ``traverse(page).as_page()`` means "find this existing tree path and treat
+    it as a page." This differs from ``page(page)``, which would create the page
+    if it were missing.
+    """
+    # ``traverse`` finds an existing page. Missing pages raise TraversalError,
+    # which callers can handle just like any other labapi error.
+    source_page = user.notebooks[notebook].traverse(page).as_page()
+    folder.mkdir(parents=True, exist_ok=True)
+    results: list[FileResult] = []
 
-    for entry in entries:
-        # JSON entries are stored as attachments. We check both MIME type and filename.
-        if isinstance(entry, AttachmentEntry):
-            attachment = entry.get_attachment()
-            is_json_mime = attachment.mime_type == "application/json"
-            is_json_ext = attachment.filename.lower().endswith(".json")
+    # A page can contain text entries, widgets, attachments, and other entry
+    # types. This example only downloads attachment entries that look like JSON.
+    for entry in source_page.entries:
+        if not isinstance(entry, AttachmentEntry):
+            continue
 
-            if is_json_mime or is_json_ext:
-                json_entries.append(entry)
-
-    if not json_entries:
-        print(f"No JSON entries found on page '{page_path}'")
-        return
-
-    print(f"Found {len(json_entries)} JSON entry/entries to download")
-
-    # Download each JSON entry
-    for entry in json_entries:
-        attachment = entry.get_attachment()
-        filename = attachment.filename
-        output_path = local_folder / filename
-
-        print(f"Downloading {filename}...", end=" ")
-
+        # ``entry.content`` downloads a fresh Attachment object. Close it when
+        # finished so local file handles or temporary buffers are released.
+        attachment = entry.content
         try:
-            # Read JSON data from attachment
-            attachment.seek(0)
-            data = json.load(attachment)
+            # Treat remote filenames as filenames, not paths. This keeps every
+            # download inside ``folder`` even if a server-provided name includes
+            # POSIX or Windows path separators.
+            filename = PureWindowsPath(PurePosixPath(attachment.filename).name).name
+            is_json = (
+                attachment.mime_type == "application/json"
+                or filename.lower().endswith(".json")
+            )
+            if not is_json:
+                continue
 
-            # Write to local file
-            with output_path.open("w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
+            output_path = folder / filename
+            try:
+                attachment.seek(0)
+                data = cast(JsonData, json.load(attachment))
+                with output_path.open("w", encoding="utf-8") as file:
+                    json.dump(data, file, indent=2)
+            except Exception as exc:
+                results.append(FileResult(filename, output_path, False, str(exc)))
+            else:
+                results.append(FileResult(filename, output_path, True))
+        finally:
+            attachment.close()
 
-            print("✓")
-        except Exception as e:
-            print(f"✗ (Error: {e})")
-
-    print(f"\nDownload complete! {len(json_entries)} file(s) saved to '{local_folder}'")
+    return results
 
 
-def main() -> None:
-    """Run the JSON sync example CLI."""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser.
+
+    The positional arguments are intentionally simple:
+
+    * upload: ``source`` is the local folder and ``destination`` is the page.
+    * download: ``source`` is the page and ``destination`` is the local folder.
+    """
     parser = argparse.ArgumentParser(
-        description="Sync JSON files between local folder and LabArchives page"
+        description="Sync JSON files between a local folder and a LabArchives page"
     )
     parser.add_argument(
         "action",
         choices=["upload", "download"],
-        help="Action to perform: upload to LabArchives or download from LabArchives",
+        help="Upload local JSON files or download LabArchives JSON entries",
     )
     parser.add_argument(
         "source",
-        help="Source: local folder path (upload) or LabArchives page path (download)",
+        help="Local folder path for upload, or LabArchives page path for download",
     )
     parser.add_argument(
         "destination",
-        help="Destination: LabArchives page path (upload) or local folder path (download)",
+        help="LabArchives page path for upload, or local folder path for download",
     )
     parser.add_argument(
         "--notebook",
@@ -182,31 +196,71 @@ def main() -> None:
         required=True,
         help="Name of the LabArchives notebook to use",
     )
+    return parser
 
-    args = parser.parse_args()
 
-    print("Connecting to LabArchives...")
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the JSON sync example CLI.
+
+    This function is the only place that authenticates, prints, or chooses a
+    process exit code. Keeping those concerns here makes the upload/download
+    functions safe to import from another script or test.
+    """
+    args = build_parser().parse_args(argv)
+
     try:
         with Client() as client:
-            print("Authenticating...")
+            # ``default_authenticate`` uses the configured labapi auth flow. With
+            # the dotenv extra, credentials can come from a local ``.env`` file.
             user = client.default_authenticate()
-            print("✓ Authenticated successfully")
 
             if args.action == "upload":
-                local_folder = Path(args.source)
-                page_path = args.destination
-                upload_json_folder(user, args.notebook, page_path, local_folder)
-            else:  # download
-                page_path = args.source
-                local_folder = Path(args.destination)
-                download_json_entries(user, args.notebook, page_path, local_folder)
-    except Exception as e:
-        print(f"Authentication error: {e}")
-        print("\nMake sure you have a .env file with your credentials:")
-        print("  ACCESS_KEYID=your_access_key_id")
-        print("  ACCESS_PWD=your_password")
-        sys.exit(1)
+                source_folder = Path(args.source)
+                upload_results = upload_json_files(
+                    user,
+                    args.notebook,
+                    args.destination,
+                    source_folder,
+                )
+                if not upload_results:
+                    print(f"No JSON files found in '{source_folder}'")
+                    return 0
+
+                successes = sum(result.success for result in upload_results)
+                print(f"Uploaded {successes}/{len(upload_results)} files")
+
+                for result in upload_results:
+                    if not result.success:
+                        print(f"Could not upload {result.name}: {result.error}")
+
+                return 0 if all(result.success for result in upload_results) else 1
+
+            destination_folder = Path(args.destination)
+            download_results = download_json_files(
+                user,
+                args.notebook,
+                args.source,
+                destination_folder,
+            )
+            if not download_results:
+                print(f"No JSON entries found on page '{args.source}'")
+                return 0
+
+            successes = sum(result.success for result in download_results)
+            print(
+                f"Downloaded {successes}/{len(download_results)} files "
+                f"to '{destination_folder}'"
+            )
+
+            for result in download_results:
+                if not result.success:
+                    print(f"Could not download {result.name}: {result.error}")
+
+            return 0 if all(result.success for result in download_results) else 1
+    except Exception as exc:
+        print(f"Error: {exc}")
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/examples/json_sync/pyproject.toml
+++ b/examples/json_sync/pyproject.toml
@@ -4,6 +4,3 @@ version = "0.1.0"
 dependencies = [
     "labapi[dotenv,builtin-auth]",
 ]
-
-[tool.uv.sources]
-labapi = { path = "../../", editable = true }

--- a/tests/examples/test_json_sync.py
+++ b/tests/examples/test_json_sync.py
@@ -3,131 +3,191 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import sys
+from collections.abc import Iterator, Sequence
+from io import BytesIO
 from pathlib import Path
+from types import TracebackType
+from typing import cast
 
 import pytest
 
-from labapi import InsertBehavior, NotebookPage, TraversalError
+from labapi import (
+    Attachment,
+    AttachmentEntry,
+    JsonData,
+    TraversalError,
+    User,
+)
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[2] / "examples" / "json_sync"
 
 
-def load_json_sync_module():
-    """Load the example script as a module for direct unit testing."""
-    script_path = (
-        Path(__file__).resolve().parents[2] / "examples" / "json_sync" / "json_sync.py"
-    )
-    spec = importlib.util.spec_from_file_location("json_sync_example", script_path)
+def _load_example_module(module_name: str, filename: str):
+    """Load an example module from the json_sync example directory."""
+    module_path = EXAMPLE_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
     assert spec is not None
     assert spec.loader is not None
 
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
     return module
 
 
-json_sync = load_json_sync_module()
+json_sync = _load_example_module("json_sync", "json_sync.py")
 
 
-class RecordingContainer:
-    """Minimal container double for get_or_create_page tests."""
+class _RecordingEntries:
+    """Minimal entries collection double."""
 
-    def __init__(self, traverse_result=None, traverse_error: Exception | None = None):
+    def __init__(self, entries: Sequence[AttachmentEntry] = ()):
+        """Initialize the entries collection double."""
+        self._entries = list(entries)
+        self.created_json: list[tuple[JsonData, str | None, str | None]] = []
+
+    def __iter__(self) -> Iterator[AttachmentEntry]:
+        """Iterate over configured entries."""
+        return iter(self._entries)
+
+    def create_json_entry(
+        self,
+        data: JsonData,
+        *,
+        filename: str | None = None,
+        caption: str | None = None,
+    ) -> None:
+        """Record JSON entry creation and return fake entry IDs."""
+        self.created_json.append((data, filename, caption))
+
+
+class _PageDouble:
+    """Minimal page double exposing entries."""
+
+    def __init__(self, entries: _RecordingEntries):
+        """Initialize the page double."""
+        self.entries = entries
+
+
+class _PageNode:
+    """Minimal tree node that resolves to a page."""
+
+    def __init__(self, page: _PageDouble):
+        """Initialize the page node."""
+        self._page = page
+
+    def is_dir(self) -> bool:
+        """Return false because this node is a page."""
+        return False
+
+    def as_page(self) -> _PageDouble:
+        """Return the configured page."""
+        return self._page
+
+
+class _RecordingContainer:
+    """Minimal container double for page traversal and creation tests."""
+
+    def __init__(
+        self,
+        traverse_result: _PageNode | None = None,
+        traverse_error: Exception | None = None,
+    ):
         """Initialize the container double with traversal behavior."""
         self.traverse_result = traverse_result
         self.traverse_error = traverse_error
-        self.create_calls: list[
-            tuple[type[NotebookPage], str, bool, InsertBehavior]
-        ] = []
+        self.page_calls: list[str] = []
 
-    def traverse(self, _path: str):
+    def traverse(self, _path: str) -> _PageNode:
         """Return the configured traversal result or raise the configured error."""
         if self.traverse_error is not None:
             raise self.traverse_error
+        assert self.traverse_result is not None
         return self.traverse_result
 
-    def create(
-        self,
-        cls: type[NotebookPage],
-        path: str,
-        *,
-        parents: bool,
-        if_exists: InsertBehavior,
-    ):
-        """Record a create request and return a sentinel page value."""
-        self.create_calls.append((cls, path, parents, if_exists))
-        return "created-page"
+    def page(self, path: str) -> _PageDouble:
+        """Record a page request and return the configured page."""
+        self.page_calls.append(path)
+        assert self.traverse_result is not None
+        return self.traverse_result.as_page()
 
 
-class DirectoryNode:
-    """Minimal non-page node for testing download error handling."""
-
-    def as_page(self):
-        """Raise because this test double does not represent a page."""
-        raise TypeError("Node is not a page")
-
-
-class NotebookDouble:
-    """Minimal notebook double for traversal-based example tests."""
-
-    def __init__(self, traverse_result=None, traverse_error: Exception | None = None):
-        """Initialize the notebook double with traversal behavior."""
-        self.traverse_result = traverse_result
-        self.traverse_error = traverse_error
-
-    def traverse(self, _path: str):
-        """Return the configured traversal result or raise the configured error."""
-        if self.traverse_error is not None:
-            raise self.traverse_error
-        return self.traverse_result
-
-
-class UserDouble:
+class _UserDouble:
     """Minimal user double exposing the notebooks mapping."""
 
-    def __init__(self, notebook):
-        """Initialize the user double with a single notebook mapping."""
+    def __init__(self, notebook: _RecordingContainer):
+        """Initialize the user double with one notebook."""
         self.notebooks = {"My Notebook": notebook}
 
 
-def test_get_or_create_page_creates_on_missing_segment():
-    """Test get_or_create_page creates the page when traversal reports a missing child."""
-    container = RecordingContainer(
-        traverse_error=TraversalError(
-            "missing child",
-            path="/Results/Page",
-            segment="Page",
-            parent="/Results",
-            available_children=["Existing Page"],
+class _ClientDouble:
+    """Minimal client context manager double."""
+
+    def __init__(self, user: _UserDouble):
+        """Initialize the client double with an authenticated user."""
+        self._user = user
+
+    def __enter__(self) -> _ClientDouble:
+        """Return this client double."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Exit the client context manager."""
+        del exc_type, exc, traceback
+
+    def default_authenticate(self) -> _UserDouble:
+        """Return the configured authenticated user."""
+        return self._user
+
+
+def _make_attachment_entry(
+    entry_id: str,
+    filename: str,
+    mime_type: str,
+    payload: bytes,
+) -> AttachmentEntry:
+    """Create an attachment entry double with in-memory content."""
+    entry = AttachmentEntry(entry_id, "caption", cast(User, object()))
+
+    def get_attachment(use_tempfile: bool = False) -> Attachment:
+        del use_tempfile
+        return Attachment(
+            BytesIO(payload),
+            mime_type,
+            filename,
+            "caption",
         )
+
+    entry.get_attachment = get_attachment
+    return entry
+
+
+def test_cli_module_import_has_no_side_effects():
+    """Test importing the CLI module does not run authentication."""
+    parser = json_sync.build_parser()
+
+    args = parser.parse_args(
+        ["upload", "sample_data", "Data/Page", "--notebook", "My Notebook"]
     )
 
-    result = json_sync.get_or_create_page(container, "Results/Page")
-
-    assert result == "created-page"
-    assert container.create_calls == [
-        (NotebookPage, "Results/Page", True, InsertBehavior.Retain)
-    ]
+    assert args.action == "upload"
+    assert args.notebook == "My Notebook"
 
 
-def test_get_or_create_page_does_not_create_on_non_directory_error():
-    """Test get_or_create_page preserves traversal errors when an intermediate segment is not a directory."""
-    container = RecordingContainer(
-        traverse_error=TraversalError(
-            "not a directory",
-            path="/Results/Page/Child",
-            segment="Child",
-            parent="/Results/Page",
-        )
-    )
-
-    with pytest.raises(TraversalError, match="not a directory"):
-        json_sync.get_or_create_page(container, "Results/Page/Child")
-
-    assert container.create_calls == []
-
-
-def test_download_json_entries_exits_on_traversal_error(capsys):
-    """Test the download helper exits cleanly when the page path is missing."""
-    notebook = NotebookDouble(
+def test_download_json_files_raises_on_traversal_error():
+    """Test the reusable download helper raises instead of exiting."""
+    notebook = _RecordingContainer(
         traverse_error=TraversalError(
             "missing child",
             path="/Missing/Page",
@@ -136,14 +196,136 @@ def test_download_json_entries_exits_on_traversal_error(capsys):
             available_children=["Existing Page"],
         )
     )
-    user = UserDouble(notebook)
+    user = _UserDouble(notebook)
 
-    with pytest.raises(SystemExit):
-        json_sync.download_json_entries(
-            user, "My Notebook", "Missing/Page", Path("download-target")
+    with pytest.raises(TraversalError, match="missing child"):
+        json_sync.download_json_files(
+            user,
+            notebook="My Notebook",
+            page="Missing/Page",
+            folder=Path("download-target"),
         )
 
-    captured = capsys.readouterr()
-    assert (
-        "Could not find page 'Missing/Page' in notebook 'My Notebook'" in captured.out
+
+def test_upload_json_files_returns_structured_results(tmp_path):
+    """Test upload returns per-file results and preserves source filenames."""
+    good_file = tmp_path / "config.json"
+    good_file.write_text('{"enabled": true}', encoding="utf-8")
+    bad_file = tmp_path / "broken.json"
+    bad_file.write_text("{", encoding="utf-8")
+
+    entries = _RecordingEntries()
+    page = _PageDouble(entries)
+    notebook = _RecordingContainer(traverse_result=_PageNode(page))
+    user = _UserDouble(notebook)
+
+    results = json_sync.upload_json_files(
+        user,
+        notebook="My Notebook",
+        page="Results/Page",
+        folder=tmp_path,
     )
+
+    assert notebook.page_calls == ["Results/Page"]
+    assert len(results) == 2
+    assert sum(result.success for result in results) == 1
+    assert entries.created_json == [({"enabled": True}, "config.json", "config")]
+    assert {result.name for result in results} == {
+        "broken.json",
+        "config.json",
+    }
+
+
+def test_upload_json_files_skips_remote_page_when_folder_has_no_json(tmp_path):
+    """Test upload returns before creating a LabArchives page when there is no work."""
+    entries = _RecordingEntries()
+    page = _PageDouble(entries)
+    notebook = _RecordingContainer(traverse_result=_PageNode(page))
+    user = _UserDouble(notebook)
+
+    results = json_sync.upload_json_files(
+        user,
+        notebook="My Notebook",
+        page="Results/Page",
+        folder=tmp_path,
+    )
+
+    assert results == []
+    assert notebook.page_calls == []
+
+
+def test_upload_json_files_validates_folder(tmp_path):
+    """Test upload raises a reusable error for missing local folders."""
+    user = _UserDouble(_RecordingContainer())
+
+    with pytest.raises(NotADirectoryError):
+        json_sync.upload_json_files(
+            user,
+            notebook="My Notebook",
+            page="Results/Page",
+            folder=tmp_path / "missing",
+        )
+
+
+def test_download_json_files_writes_json_attachments_inside_target_folder(tmp_path):
+    """Test download writes JSON-looking attachments inside the target folder."""
+    json_entry = _make_attachment_entry(
+        "entry-1",
+        "../results.json",
+        "application/octet-stream",
+        b'{"score": 42}',
+    )
+    ignored_entry = _make_attachment_entry(
+        "entry-2",
+        "notes.txt",
+        "text/plain",
+        b'{"ignored": true}',
+    )
+    entries = _RecordingEntries([json_entry, ignored_entry])
+    page = _PageDouble(entries)
+    notebook = _RecordingContainer(traverse_result=_PageNode(page))
+    user = _UserDouble(notebook)
+
+    results = json_sync.download_json_files(
+        user,
+        notebook="My Notebook",
+        page="Results/Page",
+        folder=tmp_path,
+    )
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert results[0].name == "results.json"
+    assert results[0].path == tmp_path / "results.json"
+    assert json.loads((tmp_path / "results.json").read_text(encoding="utf-8")) == {
+        "score": 42
+    }
+
+
+def test_main_upload_reports_summary_and_failures(tmp_path, monkeypatch, capsys):
+    """Test the CLI keeps output minimal while reporting failed files."""
+    good_file = tmp_path / "config.json"
+    good_file.write_text('{"enabled": true}', encoding="utf-8")
+    bad_file = tmp_path / "broken.json"
+    bad_file.write_text("{", encoding="utf-8")
+
+    entries = _RecordingEntries()
+    page = _PageDouble(entries)
+    user = _UserDouble(_RecordingContainer(traverse_result=_PageNode(page)))
+    monkeypatch.setattr(json_sync, "Client", lambda: _ClientDouble(user))
+
+    exit_code = json_sync.main(
+        [
+            "upload",
+            str(tmp_path),
+            "Results/Page",
+            "--notebook",
+            "My Notebook",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Uploaded 1/2 files" in captured.out
+    assert "Could not upload broken.json: Invalid JSON" in captured.out
+    assert "Uploaded config.json" not in captured.out


### PR DESCRIPTION
Closes #162.

## Summary
Refactors the JSON sync example so upload/download logic can be imported independently from the CLI layer.

## Validation
- Commit hook passed: Pyright, ruff check, ruff format
- uv run --python 3.10 pytest --no-cov tests\examples\test_json_sync.py
