### PR TITLE
Refactor folder download example

### DIFF
--- a/docs/source/examples/folder_download.rst
+++ b/docs/source/examples/folder_download.rst
@@ -48,22 +48,26 @@ Download an entire notebook:
 
 .. code-block:: bash
 
-   uv run python examples/folder_download/folder_download.py ./backup --notebook "My Notebook"
+   uv run --project examples/folder_download python examples/folder_download/folder_download.py ./backup --notebook "My Notebook"
 
 Download only a specific subtree:
 
 .. code-block:: bash
 
-   uv run python examples/folder_download/folder_download.py ./2024_experiments --notebook "My Notebook" --path "Experiments/2024"
+   uv run --project examples/folder_download python examples/folder_download/folder_download.py ./2024_experiments --notebook "My Notebook" --path "Experiments/2024"
 
 Overwrite an existing output directory:
 
 .. code-block:: bash
 
-   uv run python examples/folder_download/folder_download.py ./backup --notebook "My Notebook" --overwrite
+   uv run --project examples/folder_download python examples/folder_download/folder_download.py ./backup --notebook "My Notebook" --overwrite
 
 How It Works
 ------------
+
+``examples/folder_download/folder_download.py`` contains importable download
+functions plus a command-line wrapper. The reusable layer takes an authenticated
+``User`` and returns a ``DownloadResult`` instead of printing or exiting.
 
 The script mirrors the LabArchives structure:
 
@@ -126,6 +130,36 @@ Notes
 - Large notebooks may take significant time to download.
 - The script creates a ``_metadata.txt`` file for each page with additional
   information.
+
+Reusable API
+------------
+
+When building your own script, import the download function and call it
+directly. Most scripts only need ``DownloadFolderOptions`` and
+``download_notebook_or_folder``.
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from labapi import Client
+   from examples.folder_download.folder_download import (
+       DownloadFolderOptions,
+       download_notebook_or_folder,
+   )
+
+   with Client() as client:
+       user = client.default_authenticate()
+       result = download_notebook_or_folder(
+           user,
+           DownloadFolderOptions(
+               notebook_name="My Notebook",
+               output_dir=Path("notebook_export"),
+               path="Experiments/2024",
+           ),
+       )
+
+   print(f"Downloaded {result.page_count} pages and {result.entry_count} entries")
 
 Ways to Extend It
 -----------------

--- a/examples/folder_download/README.md
+++ b/examples/folder_download/README.md
@@ -2,22 +2,22 @@
 
 This example demonstrates how to download a complete LabArchives folder structure to local disk, preserving the directory hierarchy. Pages become directories, and individual entries are saved as separate files.
 
+`folder_download.py` contains reusable, typed download functions plus a small command-line interface.
+
 ## Dependencies
 
-This example requires the following packages:
+Install the example with the local authentication helpers:
 
 - `labapi[dotenv,builtin-auth]` (the core library plus local auth helpers)
-
-You can install the dependencies using:
 
 Run these commands from the repository root.
 
 ```bash
+# Using uv (recommended)
+uv sync --project examples/folder_download
+
 # Using pip
 pip install -e ".[dotenv,builtin-auth]"
-
-# Using uv (recommended)
-uv sync
 ```
 
 ## Usage
@@ -25,24 +25,24 @@ uv sync
 ### Download entire notebook
 
 ```bash
-# General usage
-python folder_download.py --notebook "My Notebook" ./output
+# General usage from the repository root
+uv run --project examples/folder_download python examples/folder_download/folder_download.py ./output --notebook "My Notebook"
 
-# Quick test from project root
-uv run python examples/folder_download/folder_download.py --notebook "My Notebook" ./notebook_export
+# Quick test
+uv run --project examples/folder_download python examples/folder_download/folder_download.py ./notebook_export --notebook "My Notebook"
 ```
 
 ### Download specific folder within a notebook
 
 ```bash
-# General usage
-python folder_download.py --notebook "My Notebook" --path "Experiments/2024" ./output/2024_experiments
+# General usage from the repository root
+uv run --project examples/folder_download python examples/folder_download/folder_download.py ./output/2024_experiments --notebook "My Notebook" --path "Experiments/2024"
 
 # Populate test data first (optional)
-uv run python examples/folder_download/populate_notebook.py --notebook "My Notebook"
+uv run --project examples/folder_download python examples/folder_download/populate_notebook.py --notebook "My Notebook"
 
-# Download specific folder from project root
-uv run python examples/folder_download/folder_download.py --notebook "My Notebook" --path "Experiments" ./notebook_export
+# Download specific folder
+uv run --project examples/folder_download python examples/folder_download/folder_download.py ./notebook_export --notebook "My Notebook" --path "Experiments"
 ```
 
 ## Options
@@ -50,6 +50,37 @@ uv run python examples/folder_download/folder_download.py --notebook "My Noteboo
 - `--notebook`, `-n`: (Required) Name of the LabArchives notebook.
 - `--path`, `-p`: Optional path within notebook (e.g., 'Experiments/2024'). If not specified, downloads entire notebook.
 - `--overwrite`: Overwrite existing files if they exist in the output directory.
+
+## Reusing the Download Logic
+
+Import the download function when you want to compose the workflow from another script:
+
+Most scripts only need `DownloadFolderOptions` and `download_notebook_or_folder`.
+
+```python
+from pathlib import Path
+
+from labapi import Client
+from examples.folder_download.folder_download import (
+    DownloadFolderOptions,
+    download_notebook_or_folder,
+)
+
+with Client() as client:
+    user = client.default_authenticate()
+    result = download_notebook_or_folder(
+        user,
+        DownloadFolderOptions(
+            notebook_name="My Notebook",
+            output_dir=Path("notebook_export"),
+            path="Experiments",
+        ),
+    )
+
+print(f"Downloaded {result.page_count} pages and {result.entry_count} entries")
+```
+
+The reusable function returns a `DownloadResult` with directory, page, entry, and error counts.
 
 ## Configuration
 

--- a/examples/folder_download/folder_download.py
+++ b/examples/folder_download/folder_download.py
@@ -1,28 +1,113 @@
 #!/usr/bin/env python3
-"""Download a LabArchives notebook folder tree to local disk."""
+"""Download a LabArchives notebook folder tree to local disk.
+
+This example has two layers:
+
+* ``download_notebook_or_folder`` is the reusable function. It takes an
+  authenticated :class:`labapi.User`, writes files to disk, and returns
+  structured counts instead of printing or exiting.
+* ``main`` is the command-line layer. It handles arguments, authentication,
+  terminal output, overwrite checks, and process exit codes.
+
+Most scripts that reuse this example only need to import
+``DownloadFolderOptions`` and ``download_notebook_or_folder``.
+
+For a first LabArchives API script, the important object chain is:
+
+``Client()`` -> ``client.default_authenticate()`` -> ``User`` ->
+``user.notebooks["Notebook Name"]`` -> ``notebook.traverse(path)`` ->
+``page.entries``.
+
+The ``User`` object represents the authenticated LabArchives account. A
+notebook is a tree-like container of folders and pages. This example walks that
+tree and writes pages, entries, attachments, and basic metadata to local files.
+"""
+
+from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
-from labapi import AbstractTreeContainer, Client, NotebookPage, User
+from labapi import (
+    AbstractTreeContainer,
+    AttachmentEntry,
+    Client,
+    Entry,
+    HeaderEntry,
+    NotebookPage,
+    PlainTextEntry,
+    TextEntry,
+    User,
+    WidgetEntry,
+)
+
+
+@dataclass(frozen=True)
+class DownloadFolderOptions:
+    """Inputs needed to export one notebook or notebook subtree."""
+
+    notebook_name: str
+    output_dir: Path
+    path: str | None = None
+
+
+@dataclass(frozen=True)
+class EntryDownloadError:
+    """Details for one entry that could not be exported."""
+
+    entry_index: int
+    entry_id: str
+    content_type: str
+    error: str
+    error_file: Path
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    """Summary of a folder-download export."""
+
+    output_dir: Path
+    directory_count: int = 0
+    page_count: int = 0
+    entry_count: int = 0
+    errors: tuple[EntryDownloadError, ...] = ()
+
+    @property
+    def error_count(self) -> int:
+        """Return the number of entries that failed during export."""
+        return len(self.errors)
+
+    def merge(self, other: DownloadResult) -> DownloadResult:
+        """Return a combined result for adjacent export operations."""
+        return DownloadResult(
+            self.output_dir,
+            self.directory_count + other.directory_count,
+            self.page_count + other.page_count,
+            self.entry_count + other.entry_count,
+            self.errors + other.errors,
+        )
 
 
 def sanitize_filename(name: str) -> str:
     """Sanitize a name to be safe for filesystem use."""
-    # Replace problematic characters
     unsafe_chars = '<>:"/\\|?*'
     for char in unsafe_chars:
         name = name.replace(char, "_")
 
-    # Remove leading/trailing spaces and dots
     name = name.strip(". ")
-
-    # Limit length to avoid filesystem issues
     if len(name) > 200:
         name = name[:200]
 
     return name or "untitled"
+
+
+def _sanitize_remote_filename(name: str) -> str:
+    """Return a filesystem-safe basename for a remote LabArchives filename."""
+    filename = PureWindowsPath(PurePosixPath(name).name).name
+    return sanitize_filename(filename)
 
 
 def get_unique_path(
@@ -48,133 +133,158 @@ def get_unique_path(
     return candidate
 
 
-def download_page(page: NotebookPage, output_dir: Path, used_paths: set[Path]) -> None:
-    """Download a page and its entries to a directory."""
+def _download_page(
+    page: NotebookPage, output_dir: Path, used_paths: set[Path]
+) -> DownloadResult:
+    """Download one LabArchives page and its entries to a local directory."""
     page_dir = get_unique_path(output_dir, page.name, used_paths, page.id)
     page_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"  Downloading page: {page.name}")
+    _write_page_metadata(page, page_dir)
 
-    # Save page metadata
-    metadata_file = page_dir / "_metadata.txt"
-    with metadata_file.open("w", encoding="utf-8") as f:
-        f.write(f"Page: {page.name}\n")
-        f.write(f"ID: {page.id}\n")
-        f.write(f"Entry count: {len(page.entries)}\n")
+    errors: list[EntryDownloadError] = []
+    for index, entry in enumerate(page.entries, start=1):
+        error = _download_entry(entry, index, page_dir)
+        if error is not None:
+            errors.append(error)
 
-    # Maps content_type → (filename suffix, display label)
-    text_entry_types = {
-        "text entry": ("_text.html", "Text entry"),
-        "plain text entry": ("_plaintext.txt", "Plain text entry"),
-        "heading": ("_header.txt", "Header"),
-    }
-
-    # Download each entry
-    for i, entry in enumerate(page.entries, start=1):
-        entry_prefix = f"{i:03d}"
-
-        try:
-            if entry.content_type == "Attachment":
-                attachment = entry.content
-                filename = sanitize_filename(attachment.filename)
-                output_path = page_dir / f"{entry_prefix}_attachment_{filename}"
-                print(f"    Entry {i}: Attachment - {filename}")
-                with output_path.open("wb") as f:
-                    attachment.seek(0)
-                    f.write(attachment.read())
-                if attachment.caption:
-                    caption_file = page_dir / f"{entry_prefix}_caption.txt"
-                    with caption_file.open("w", encoding="utf-8") as f:
-                        f.write(attachment.caption)
-
-            elif entry.content_type in text_entry_types:
-                suffix, label = text_entry_types[entry.content_type]
-                output_path = page_dir / f"{entry_prefix}{suffix}"
-                print(f"    Entry {i}: {label}")
-                with output_path.open("w", encoding="utf-8") as f:
-                    f.write(entry.content)
-
-            elif entry.content_type == "widget entry":
-                output_path = page_dir / f"{entry_prefix}_widget.txt"
-                print(f"    Entry {i}: Widget (read-only)")
-                with output_path.open("w", encoding="utf-8") as f:
-                    f.write(
-                        f"Widget Entry (ID: {entry.id})\nNote: Widget entries are read-only and cannot be fully exported\n"
-                    )
-
-            else:
-                output_path = page_dir / f"{entry_prefix}_unknown.txt"
-                print(f"    Entry {i}: Unknown type ({entry.content_type})")
-                with output_path.open("w", encoding="utf-8") as f:
-                    f.write(
-                        f"Unknown entry type: {entry.content_type}\nEntry ID: {entry.id}\n"
-                    )
-
-        except Exception as e:
-            print(f"    Entry {i}: Error - {e}")
-            error_file = page_dir / f"{entry_prefix}_error.txt"
-            with error_file.open("w", encoding="utf-8") as f:
-                f.write(
-                    f"Error downloading entry {i}: {e}\nEntry type: {entry.content_type}\n"
-                )
+    return DownloadResult(
+        output_dir=output_dir,
+        page_count=1,
+        entry_count=len(page.entries),
+        errors=tuple(errors),
+    )
 
 
-def download_directory(
+def _download_directory(
     directory: AbstractTreeContainer, output_dir: Path, used_paths: set[Path]
-) -> None:
-    """Recursively download a directory and its contents."""
-    dir_path = get_unique_path(output_dir, directory.name, used_paths, directory.id)
-    dir_path.mkdir(parents=True, exist_ok=True)
+) -> DownloadResult:
+    """Recursively download a LabArchives directory and its contents."""
+    directory_path = get_unique_path(
+        output_dir, directory.name, used_paths, directory.id
+    )
+    directory_path.mkdir(parents=True, exist_ok=True)
 
-    print(f"Downloading directory: {directory.name}")
-
-    # Process all children
+    result = DownloadResult(output_dir=output_dir, directory_count=1)
     for child in directory.children:
         if child.is_dir():
-            # Recursively download subdirectory
-            download_directory(child.as_dir(), dir_path, used_paths)
+            child_result = _download_directory(
+                child.as_dir(), directory_path, used_paths
+            )
         else:
-            # Download page
-            download_page(child.as_page(), dir_path, used_paths)
+            child_result = _download_page(child.as_page(), directory_path, used_paths)
+        result = result.merge(child_result)
+
+    return result
 
 
 def download_notebook_or_folder(
-    user: User, notebook_name: str, path: str | None, output_dir: Path
-) -> None:
-    """Download a notebook or folder from LabArchives."""
-    notebooks = user.notebooks
+    user: User, options: DownloadFolderOptions
+) -> DownloadResult:
+    """Download a notebook, folder, or page from LabArchives.
+
+    The reusable function assumes ``user`` is already authenticated. It does not
+    parse command-line arguments, print progress, or choose process exit codes.
+    Missing notebooks, invalid paths, and other labapi errors propagate to the
+    caller.
+    """
+    notebook = user.notebooks[options.notebook_name]
+    target = notebook.traverse(options.path) if options.path else notebook
+    options.output_dir.mkdir(parents=True, exist_ok=True)
+
+    used_paths: set[Path] = set()
+    if target.is_dir():
+        return _download_directory(target.as_dir(), options.output_dir, used_paths)
+    return _download_page(target.as_page(), options.output_dir, used_paths)
+
+
+def _write_page_metadata(page: NotebookPage, page_dir: Path) -> None:
+    """Write metadata for one downloaded page."""
+    metadata_file = page_dir / "_metadata.txt"
+    with metadata_file.open("w", encoding="utf-8") as handle:
+        handle.write(f"Page: {page.name}\n")
+        handle.write(f"ID: {page.id}\n")
+        handle.write(f"Entry count: {len(page.entries)}\n")
+
+
+def _download_entry(
+    entry: Entry[object], entry_index: int, page_dir: Path
+) -> EntryDownloadError | None:
+    """Download one page entry and return error details when it fails."""
     try:
-        notebook = notebooks[notebook_name]
-
-        # Navigate to subfolder if specified
-        if path:
-            print(f"Navigating to: {path}")
-            target = notebook.traverse(path)
-        else:
-            target = notebook
-
-        used_paths: set[Path] = set()
-
-        # Download the target
-        if target.is_dir():
-            download_directory(target.as_dir(), output_dir, used_paths)
-        else:
-            # It's a page
-            download_page(target.as_page(), output_dir, used_paths)
-
-        print(f"\nDownload complete! Content saved to: {output_dir.absolute()}")
-
-    except KeyError as e:
-        print(f"Error: Could not find notebook '{notebook_name}' or path '{path}': {e}")
-        print(f"Available notebooks: {list(notebooks.keys())}")
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error during download: {e}")
-        sys.exit(1)
+        _write_entry(entry, entry_index, page_dir)
+    except Exception as exc:
+        error_file = page_dir / f"{entry_index:03d}_error.txt"
+        with error_file.open("w", encoding="utf-8") as handle:
+            handle.write(
+                f"Error downloading entry {entry_index}: {exc}\n"
+                f"Entry type: {entry.content_type}\n"
+            )
+        return EntryDownloadError(
+            entry_index=entry_index,
+            entry_id=entry.id,
+            content_type=entry.content_type,
+            error=str(exc),
+            error_file=error_file,
+        )
+    return None
 
 
-def main() -> None:
-    """Run the folder download example CLI."""
+def _write_entry(entry: Entry[object], entry_index: int, page_dir: Path) -> None:
+    """Write one LabArchives entry to disk."""
+    entry_prefix = f"{entry_index:03d}"
+
+    # Each LabArchives entry type gets a simple local representation that is
+    # easy to inspect without re-running the API client.
+    if isinstance(entry, AttachmentEntry):
+        _write_attachment_entry(entry, entry_prefix, page_dir)
+    elif isinstance(entry, HeaderEntry):
+        _write_text_entry(entry, page_dir / f"{entry_prefix}_header.txt")
+    elif isinstance(entry, TextEntry):
+        _write_text_entry(entry, page_dir / f"{entry_prefix}_text.html")
+    elif isinstance(entry, PlainTextEntry):
+        _write_text_entry(entry, page_dir / f"{entry_prefix}_plaintext.txt")
+    elif isinstance(entry, WidgetEntry):
+        output_path = page_dir / f"{entry_prefix}_widget.txt"
+        with output_path.open("w", encoding="utf-8") as handle:
+            handle.write(
+                f"Widget Entry (ID: {entry.id})\n"
+                "Note: Widget entries are read-only and cannot be fully exported\n"
+            )
+    else:
+        output_path = page_dir / f"{entry_prefix}_unknown.txt"
+        with output_path.open("w", encoding="utf-8") as handle:
+            handle.write(f"Unknown entry type: {entry.content_type}\n")
+            handle.write(f"Entry ID: {entry.id}\n")
+
+
+def _write_attachment_entry(
+    entry: AttachmentEntry, entry_prefix: str, page_dir: Path
+) -> None:
+    """Write one attachment entry and optional caption to disk."""
+    attachment = entry.content
+    try:
+        filename = _sanitize_remote_filename(attachment.filename)
+        output_path = page_dir / f"{entry_prefix}_attachment_{filename}"
+        with output_path.open("wb") as handle:
+            attachment.seek(0)
+            handle.write(attachment.read())
+        if attachment.caption:
+            caption_file = page_dir / f"{entry_prefix}_caption.txt"
+            with caption_file.open("w", encoding="utf-8") as handle:
+                handle.write(attachment.caption)
+    finally:
+        attachment.close()
+
+
+def _write_text_entry(entry: PlainTextEntry, output_path: Path) -> None:
+    """Write one text-like entry to disk."""
+    with output_path.open("w", encoding="utf-8") as handle:
+        handle.write(entry.content)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(
         description="Download LabArchives folder structure to local disk"
     )
@@ -188,37 +298,52 @@ def main() -> None:
     parser.add_argument(
         "--path",
         "-p",
-        help="Optional path within notebook (e.g., 'Experiments/2024'). If not specified, downloads entire notebook.",
+        help=(
+            "Optional path within notebook, for example 'Experiments/2024'. "
+            "When omitted, downloads the entire notebook."
+        ),
     )
     parser.add_argument(
         "--overwrite", action="store_true", help="Overwrite existing files"
     )
+    return parser
 
-    args = parser.parse_args()
 
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the command-line script and return a process exit code."""
+    args = _build_parser().parse_args(argv)
     output_dir = Path(args.output)
 
-    # Check if output directory exists
     if output_dir.exists() and not args.overwrite and any(output_dir.iterdir()):
         print(f"Error: Output directory '{output_dir}' exists and is not empty")
         print("Use --overwrite to overwrite existing files")
-        sys.exit(1)
+        return 1
 
-    print("Connecting to LabArchives...")
     try:
         with Client() as client:
-            print("Authenticating...")
             user = client.default_authenticate()
-            print("✓ Authenticated successfully")
+            result = download_notebook_or_folder(
+                user,
+                DownloadFolderOptions(
+                    notebook_name=args.notebook,
+                    output_dir=output_dir,
+                    path=args.path,
+                ),
+            )
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
-            download_notebook_or_folder(user, args.notebook, args.path, output_dir)
-    except Exception as e:
-        print(f"Authentication error: {e}")
-        print("\nMake sure you have a .env file with your credentials:")
-        print("  ACCESS_KEYID=your_access_key_id")
-        print("  ACCESS_PWD=your_password")
-        sys.exit(1)
+    print(
+        f"Downloaded {result.directory_count} directories, "
+        f"{result.page_count} pages, and {result.entry_count} entries "
+        f"to '{result.output_dir}'"
+    )
+    if result.error_count:
+        print(f"{result.error_count} entries could not be fully exported")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/examples/folder_download/pyproject.toml
+++ b/examples/folder_download/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "example-folder-download"
 version = "0.1.0"
+requires-python = ">=3.10"
 dependencies = [
     "labapi[dotenv,builtin-auth]",
 ]

--- a/tests/examples/test_folder_download.py
+++ b/tests/examples/test_folder_download.py
@@ -3,7 +3,24 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
+from io import BytesIO
 from pathlib import Path
+from types import TracebackType
+from typing import cast
+
+import pytest
+
+from labapi import (
+    Attachment,
+    AttachmentEntry,
+    HeaderEntry,
+    PlainTextEntry,
+    TextEntry,
+    UnknownEntry,
+    User,
+    WidgetEntry,
+)
 
 
 def load_folder_download_module():
@@ -14,31 +31,166 @@ def load_folder_download_module():
         / "folder_download"
         / "folder_download.py"
     )
-    spec = importlib.util.spec_from_file_location(
-        "folder_download_example", script_path
-    )
+    module_name = "folder_download_example"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
     assert spec is not None
     assert spec.loader is not None
 
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    previous_module = sys.modules.get(module_name)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
     return module
 
 
 folder_download = load_folder_download_module()
 
 
-class FakePage:
-    """Minimal page double for exercising the download helper."""
+class _PageDouble:
+    """Minimal page double exposing entries."""
 
-    def __init__(self, name: str, page_id: str):
-        """Initialize the fake page metadata."""
+    def __init__(
+        self,
+        name: str,
+        page_id: str,
+        entries: list[object] | None = None,
+    ):
+        """Initialize the page metadata and entries."""
         self.name = name
         self.id = page_id
-        self.entries = []
+        self.entries = entries or []
+
+    def is_dir(self) -> bool:
+        """Return false because this node is a page."""
+        return False
+
+    def as_page(self) -> _PageDouble:
+        """Return this page."""
+        return self
 
 
-def test_get_unique_path_returns_sanitized_name(tmp_path):
+class _DirectoryDouble:
+    """Minimal directory/notebook double exposing children."""
+
+    def __init__(
+        self,
+        name: str,
+        directory_id: str,
+        children: list[object] | None = None,
+        traverse_result: object | None = None,
+    ):
+        """Initialize the directory metadata and traversal behavior."""
+        self.name = name
+        self.id = directory_id
+        self.children = children or []
+        self.traverse_result = traverse_result
+        self.traverse_calls: list[str] = []
+
+    def is_dir(self) -> bool:
+        """Return true because this node is a directory."""
+        return True
+
+    def as_dir(self) -> _DirectoryDouble:
+        """Return this directory."""
+        return self
+
+    def traverse(self, path: str) -> object:
+        """Record traversal and return the configured node."""
+        self.traverse_calls.append(path)
+        assert self.traverse_result is not None
+        return self.traverse_result
+
+
+class _UserDouble:
+    """Minimal user double exposing the notebooks mapping."""
+
+    def __init__(self, notebook: _DirectoryDouble):
+        """Initialize the user double with one notebook."""
+        self.notebooks = {"My Notebook": notebook}
+
+
+class _ClientDouble:
+    """Minimal client context manager double."""
+
+    def __init__(self, user: _UserDouble):
+        """Initialize the client double with an authenticated user."""
+        self._user = user
+
+    def __enter__(self) -> _ClientDouble:
+        """Return this client double."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Exit the client context manager."""
+        del exc_type, exc, traceback
+
+    def default_authenticate(self) -> _UserDouble:
+        """Return the configured authenticated user."""
+        return self._user
+
+
+def _user() -> User:
+    """Return a typed user placeholder for entry doubles."""
+    return cast(User, object())
+
+
+def _attachment_entry(
+    entry_id: str,
+    payload: bytes,
+    *,
+    filename: str = "data.csv",
+    caption: str = "",
+) -> AttachmentEntry:
+    """Create an attachment entry double with in-memory content."""
+    entry = AttachmentEntry(entry_id, caption, _user())
+
+    def get_attachment(use_tempfile: bool = False) -> Attachment:
+        del use_tempfile
+        return Attachment(
+            BytesIO(payload),
+            "application/octet-stream",
+            filename,
+            caption,
+        )
+
+    entry.get_attachment = get_attachment
+    return entry
+
+
+def _failing_attachment_entry(entry_id: str) -> AttachmentEntry:
+    """Create an attachment entry double that fails during content retrieval."""
+    entry = AttachmentEntry(entry_id, "caption", _user())
+
+    def get_attachment(use_tempfile: bool = False) -> Attachment:
+        del use_tempfile
+        raise RuntimeError("content unavailable")
+
+    entry.get_attachment = get_attachment
+    return entry
+
+
+def test_cli_module_import_has_no_side_effects():
+    """Test importing the CLI module does not run authentication."""
+    parser = folder_download._build_parser()
+
+    args = parser.parse_args(["./backup", "--notebook", "My Notebook"])
+
+    assert args.output == "./backup"
+    assert args.notebook == "My Notebook"
+
+
+def test_get_unique_path_returns_sanitized_name(tmp_path: Path):
     """Test unique paths preserve the original sanitized name when unused."""
     used_paths: set[Path] = set()
 
@@ -53,7 +205,7 @@ def test_get_unique_path_returns_sanitized_name(tmp_path):
     assert path in used_paths
 
 
-def test_get_unique_path_uses_id_suffix_on_collision(tmp_path):
+def test_get_unique_path_uses_id_suffix_on_collision(tmp_path: Path):
     """Test colliding sanitized names are disambiguated with the node id."""
     used_paths: set[Path] = set()
 
@@ -74,16 +226,132 @@ def test_get_unique_path_uses_id_suffix_on_collision(tmp_path):
     assert second == tmp_path / "Experiment_1_page-two"
 
 
-def test_download_page_uses_collision_safe_directory_names(tmp_path):
+def test_download_page_writes_supported_entries_without_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Test page download writes files and keeps reusable output quiet."""
+    page = _PageDouble(
+        "Experiment:1",
+        "page-one",
+        [
+            HeaderEntry("entry-1", "Summary", _user()),
+            TextEntry("entry-2", "<p>Results</p>", _user()),
+            PlainTextEntry("entry-3", "notes", _user()),
+            _attachment_entry(
+                "entry-4",
+                b"sample,data\n",
+                filename="../data.csv",
+                caption="Data caption",
+            ),
+            WidgetEntry("entry-5", "ignored", _user()),
+            UnknownEntry("entry-6", "payload", _user(), part_type="future entry"),
+        ],
+    )
+
+    result = folder_download._download_page(page, tmp_path, set())
+
+    captured = capsys.readouterr()
+    page_dir = tmp_path / "Experiment_1"
+    assert captured.out == ""
+    assert captured.err == ""
+    assert result.page_count == 1
+    assert result.entry_count == 6
+    assert result.error_count == 0
+    assert (page_dir / "_metadata.txt").read_text(encoding="utf-8") == (
+        "Page: Experiment:1\nID: page-one\nEntry count: 6\n"
+    )
+    assert (page_dir / "001_header.txt").read_text(encoding="utf-8") == "Summary"
+    assert (page_dir / "002_text.html").read_text(encoding="utf-8") == "<p>Results</p>"
+    assert (page_dir / "003_plaintext.txt").read_text(encoding="utf-8") == "notes"
+    assert (page_dir / "004_attachment_data.csv").read_bytes() == b"sample,data\n"
+    assert (page_dir / "004_caption.txt").read_text(encoding="utf-8") == "Data caption"
+    assert "Widget Entry" in (page_dir / "005_widget.txt").read_text(encoding="utf-8")
+    assert "future entry" in (page_dir / "006_unknown.txt").read_text(encoding="utf-8")
+
+
+def test_download_page_uses_collision_safe_directory_names(tmp_path: Path):
     """Test page downloads do not merge different names into one directory."""
     used_paths: set[Path] = set()
 
-    folder_download.download_page(
-        FakePage("Experiment:1", "page-one"), tmp_path, used_paths
+    folder_download._download_page(
+        _PageDouble("Experiment:1", "page-one"), tmp_path, used_paths
     )
-    folder_download.download_page(
-        FakePage("Experiment/1", "page-two"), tmp_path, used_paths
+    folder_download._download_page(
+        _PageDouble("Experiment/1", "page-two"), tmp_path, used_paths
     )
 
     assert (tmp_path / "Experiment_1").is_dir()
     assert (tmp_path / "Experiment_1_page-two").is_dir()
+
+
+def test_download_page_records_entry_errors(tmp_path: Path):
+    """Test failed entries are captured in the result and error file."""
+    page = _PageDouble(
+        "Experiment",
+        "page-one",
+        [_failing_attachment_entry("entry-error")],
+    )
+
+    result = folder_download._download_page(page, tmp_path, set())
+
+    error_file = tmp_path / "Experiment" / "001_error.txt"
+    assert result.entry_count == 1
+    assert result.error_count == 1
+    assert result.errors[0].entry_id == "entry-error"
+    assert result.errors[0].error_file == error_file
+    assert "content unavailable" in error_file.read_text(encoding="utf-8")
+
+
+def test_download_notebook_or_folder_returns_structured_summary(tmp_path: Path):
+    """Test reusable notebook download traverses and summarizes a subtree."""
+    page = _PageDouble(
+        "Results",
+        "page-one",
+        [PlainTextEntry("entry-1", "value", _user())],
+    )
+    directory = _DirectoryDouble("Experiments", "dir-one", [page])
+    notebook = _DirectoryDouble(
+        "My Notebook", "notebook-one", traverse_result=directory
+    )
+    user = _UserDouble(notebook)
+
+    result = folder_download.download_notebook_or_folder(
+        user,
+        folder_download.DownloadFolderOptions(
+            notebook_name="My Notebook",
+            output_dir=tmp_path,
+            path="Experiments",
+        ),
+    )
+
+    assert notebook.traverse_calls == ["Experiments"]
+    assert result.directory_count == 1
+    assert result.page_count == 1
+    assert result.entry_count == 1
+    assert (tmp_path / "Experiments" / "Results" / "001_plaintext.txt").read_text(
+        encoding="utf-8"
+    ) == "value"
+
+
+def test_main_reports_summary_and_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """Test the CLI owns output and process exit codes."""
+    output_dir = tmp_path / "export"
+    page = _PageDouble(
+        "Results",
+        "page-one",
+        [_failing_attachment_entry("entry-error")],
+    )
+    notebook = _DirectoryDouble("My Notebook", "notebook-one", [page])
+    user = _UserDouble(notebook)
+    monkeypatch.setattr(folder_download, "Client", lambda: _ClientDouble(user))
+
+    exit_code = folder_download.main([str(output_dir), "--notebook", "My Notebook"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Downloaded 1 directories, 1 pages, and 1 entries" in captured.out
+    assert "1 entries could not be fully exported" in captured.out


### PR DESCRIPTION
## Summary
- Split the folder download example into a reusable download function and a thin CLI layer.
- Return structured download counts and entry error details instead of printing or exiting from reusable code.
- Update README, docs, pyproject metadata, and tests for the reusable example API.

## Validation
- uv run --python 3.10 pytest --no-cov
- uv run --python 3.10 ruff format --check .
- uv run --python 3.10 ruff check .
- uv run --python 3.10 pyright
- uv run --python 3.10 ty check --python-version 3.10
- uv run --python 3.10 sphinx-build -b html docs/source docs/_build/html

Closes #163