### PR TITLE
Add notebook entry search

### DIFF
--- a/docs/source/guide/entries.rst
+++ b/docs/source/guide/entries.rst
@@ -24,6 +24,28 @@ You can access the entries of a :class:`~labapi.tree.page.NotebookPage` through 
    # Access an entry by index
    first_entry = page.entries[0]
 
+Searching Entries
+-----------------
+
+Use :meth:`~labapi.tree.notebook.Notebook.search` to search entries in a
+notebook. Search returns an iterable of result pages, and each page contains
+normal entry objects.
+
+.. code-block:: python
+
+   from labapi import TextEntry
+
+   for result_page in notebook.search('"brown rat"', page_size=100):
+       for entry in result_page.entries:
+           if isinstance(entry, TextEntry):
+               entry.content = entry.content.replace(
+                   "brown rat",
+                   "Rattus norvegicus",
+               )
+
+The search request itself is read-only. Returned entries use the same
+``content`` accessors and setters as entries loaded from ``page.entries``.
+
 Entry Types
 -----------
 

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from typing_extensions import override
 
 from .mixins import AbstractTreeContainer, HasNameMixin
+from .search import EntrySearch
 
 if TYPE_CHECKING:
     from labapi.user import User
@@ -69,3 +70,16 @@ class Notebook(AbstractTreeContainer):
         :returns: True if the notebook is the default, False otherwise.
         """
         return self._is_default
+
+    def search(self, query: str, *, page_size: int = 25) -> EntrySearch:
+        """Search entries in this notebook.
+
+        Search itself is read-only. The returned pages contain normal entry
+        objects, so setting ``entry.content`` still uses the existing entry
+        update behavior.
+
+        :param query: LabArchives search query expression.
+        :param page_size: Number of entries to request per result page.
+        :returns: A lazy iterable over search result pages.
+        """
+        return EntrySearch(self, query, page_size=page_size)

--- a/src/labapi/tree/search.py
+++ b/src/labapi/tree/search.py
@@ -1,0 +1,118 @@
+"""Search result objects for LabArchives notebooks."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from labapi.entry import Entry
+from labapi.util import extract_etree
+
+if TYPE_CHECKING:
+    from .notebook import Notebook
+
+
+@dataclass(frozen=True)
+class EntrySearchPage:
+    """One page of LabArchives entry search results."""
+
+    page_size: int
+    page_number: int
+    total_found: int
+    total_returned: int
+    entries: tuple[Entry[Any], ...]
+
+
+class EntrySearch:
+    """Lazy entry search over a LabArchives notebook."""
+
+    def __init__(self, notebook: Notebook, query: str, *, page_size: int):
+        """Initialize a notebook entry search."""
+        if page_size <= 0:
+            raise ValueError("page_size must be positive")
+
+        self._notebook = notebook
+        self._query = query
+        self._page_size = page_size
+
+    def __iter__(self) -> Iterator[EntrySearchPage]:
+        """Iterate through search result pages until all results are exhausted."""
+        page_number = 0
+
+        while True:
+            page = self.page(page_number)
+            if page.total_returned == 0:
+                return
+
+            yield page
+
+            returned_so_far = page.page_number * page.page_size + page.total_returned
+            if returned_so_far >= page.total_found:
+                return
+
+            page_number += 1
+
+    def page(self, page_number: int) -> EntrySearchPage:
+        """Return one zero-based search result page.
+
+        :raises IndexError: If ``page_number`` is negative or out of range.
+        """
+        if page_number < 0:
+            raise IndexError("search page index must be non-negative")
+
+        response = self._notebook.user.api_get(
+            "search_tools/entry_search",
+            nbid=self._notebook.id,
+            query=self._query,
+            page_size=self._page_size,
+            page_number=page_number,
+            entry_data=True,
+        )
+        result_counts = extract_etree(
+            response,
+            {"results": {"total-found": int, "total-returned": int}},
+        )
+
+        entries: list[Entry[Any]] = []
+        for entry_element in response.findall("./entries/entry"):
+            entry_fields = extract_etree(entry_element, {"eid": str, "part-type": str})
+
+            entry_data = entry_element.find("./entry-data")
+            caption = entry_element.find("./caption")
+
+            data = ""
+            if (
+                entry_data is not None
+                and entry_data.get("nil") != "true"
+                and entry_data.text is not None
+            ):
+                data = entry_data.text
+            elif (
+                caption is not None
+                and caption.get("nil") != "true"
+                and caption.text is not None
+            ):
+                data = caption.text
+
+            entries.append(
+                Entry.from_part_type(
+                    entry_fields["part-type"],
+                    entry_fields["eid"],
+                    data,
+                    self._notebook.user,
+                )
+            )
+
+        page = EntrySearchPage(
+            page_size=self._page_size,
+            page_number=page_number,
+            total_found=result_counts["total-found"],
+            total_returned=result_counts["total-returned"],
+            entries=tuple(entries),
+        )
+
+        if page_number > 0 and page.total_returned == 0:
+            raise IndexError(f"search page index {page_number} is out of range")
+
+        return page

--- a/tests/tree/test_notebook.py
+++ b/tests/tree/test_notebook.py
@@ -4,10 +4,32 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
-from labapi import Notebook
+import pytest
+
+from labapi import (
+    AttachmentEntry,
+    HeaderEntry,
+    Notebook,
+    PlainTextEntry,
+    TextEntry,
+    UnknownEntry,
+)
 from labapi.tree.collection import Notebooks
 from labapi.user import User
 from labapi.util.types import NotebookInit
+
+
+def search_response(client, *entries, total_found: int, total_returned: int):
+    """Build an entry-search API response."""
+    return client.xml(
+        "search-tools",
+        client.xml(
+            "results",
+            client.xml("total-found", total_found, type="integer"),
+            client.xml("total-returned", total_returned, type="integer"),
+        ),
+        client.xml("entries", *entries, type="array"),
+    )
 
 
 class TestNotebookUnit:
@@ -25,6 +47,18 @@ class TestNotebookUnit:
         assert notebook.name == "Test Notebook"
         assert notebook.is_default is True
         assert notebook.root is notebook
+
+    def test_search_is_lazy(self):
+        """Test Notebook.search does not call the API until a page is requested."""
+        mock_user = Mock(spec=User)
+        mock_notebooks = Mock(spec=Notebooks)
+
+        init = NotebookInit(id="nb_test", name="Test Notebook", is_default=True)
+        notebook = Notebook(init, mock_user, mock_notebooks)
+
+        _ = notebook.search("brown rat", page_size=50)
+
+        mock_user.api_get.assert_not_called()
 
 
 class TestNotebookIntegration:
@@ -44,3 +78,193 @@ class TestNotebookIntegration:
         assert api_call[1]["nbid"] == "testnb1"
         assert api_call[1]["name"] == "Updated Notebook Name"
         assert notebook.name == "Updated Notebook Name"
+
+    def test_search_page_returns_entries(self, client, notebook: Notebook):
+        """Test entry search calls the search endpoint and returns entry objects."""
+        client.api_response = search_response(
+            client,
+            client.xml(
+                "entry",
+                client.xml("eid", "text-1"),
+                client.xml("part-type", "text entry"),
+                client.xml("entry-data", "<p>brown rat</p>"),
+            ),
+            client.xml(
+                "entry",
+                client.xml("eid", "header-1"),
+                client.xml("part-type", "heading"),
+                client.xml("entry-data", "Results"),
+            ),
+            client.xml(
+                "entry",
+                client.xml("eid", "plain-1"),
+                client.xml("part-type", "plain text entry"),
+                client.xml("entry-data", "notes"),
+            ),
+            client.xml(
+                "entry",
+                client.xml("eid", "attachment-1"),
+                client.xml("part-type", "Attachment"),
+                client.xml("caption", "data file"),
+            ),
+            client.xml(
+                "entry",
+                client.xml("eid", "future-1"),
+                client.xml("part-type", "future entry"),
+                client.xml("entry-data", "payload"),
+            ),
+            total_found=5,
+            total_returned=5,
+        )
+
+        page = notebook.search("brown rat", page_size=10).page(0)
+
+        api_call = client.pop_api_call()
+        assert api_call[0] == "search_tools/entry_search"
+        assert api_call[1] == {
+            "uid": "testid1",
+            "nbid": "testnb1",
+            "query": "brown rat",
+            "page_size": 10,
+            "page_number": 0,
+            "entry_data": True,
+        }
+        assert page.page_size == 10
+        assert page.page_number == 0
+        assert page.total_found == 5
+        assert page.total_returned == 5
+        text_entry = page.entries[0]
+        header_entry = page.entries[1]
+        plain_text_entry = page.entries[2]
+        attachment_entry = page.entries[3]
+        unknown_entry = page.entries[4]
+        assert isinstance(text_entry, TextEntry)
+        assert isinstance(header_entry, HeaderEntry)
+        assert isinstance(plain_text_entry, PlainTextEntry)
+        assert isinstance(attachment_entry, AttachmentEntry)
+        assert isinstance(unknown_entry, UnknownEntry)
+        assert text_entry.content == "<p>brown rat</p>"
+        assert attachment_entry.caption == "data file"
+
+    def test_search_result_entries_use_existing_update_endpoint(
+        self, client, notebook: Notebook
+    ):
+        """Test search results are normal entries that update by entry id."""
+        client.api_response = search_response(
+            client,
+            client.xml(
+                "entry",
+                client.xml("eid", "text-1"),
+                client.xml("part-type", "text entry"),
+                client.xml("entry-data", "<p>brown rat</p>"),
+            ),
+            total_found=1,
+            total_returned=1,
+        )
+
+        entry = notebook.search("brown rat").page(0).entries[0]
+        _ = client.pop_api_call()
+
+        assert isinstance(entry, TextEntry)
+        client.api_response = client.xml("entries", client.xml("success", True))
+
+        entry.content = entry.content.replace("brown rat", "Rattus norvegicus")
+
+        api_call = client.pop_api_call()
+        assert api_call[0] == "entries/update_entry"
+        assert api_call[1]["uid"] == "testid1"
+        assert api_call[1]["eid"] == "text-1"
+        assert api_call[1]["entry_data"] == "<p>Rattus norvegicus</p>"
+
+    def test_search_iteration_fetches_pages(self, client, notebook: Notebook):
+        """Test entry search iteration follows result pages until complete."""
+        client.api_response = search_response(
+            client,
+            client.xml(
+                "entry",
+                client.xml("eid", "text-1"),
+                client.xml("part-type", "text entry"),
+                client.xml("entry-data", "first"),
+            ),
+            client.xml(
+                "entry",
+                client.xml("eid", "text-2"),
+                client.xml("part-type", "text entry"),
+                client.xml("entry-data", "second"),
+            ),
+            total_found=3,
+            total_returned=2,
+        )
+        client.api_response = search_response(
+            client,
+            client.xml(
+                "entry",
+                client.xml("eid", "text-3"),
+                client.xml("part-type", "text entry"),
+                client.xml("entry-data", "third"),
+            ),
+            total_found=3,
+            total_returned=1,
+        )
+
+        pages = list(notebook.search("brown rat", page_size=2))
+
+        first_call = client.pop_api_call()
+        second_call = client.pop_api_call()
+        assert first_call[1]["page_number"] == 0
+        assert second_call[1]["page_number"] == 1
+        assert [page.page_number for page in pages] == [0, 1]
+        assert [entry.id for page in pages for entry in page.entries] == [
+            "text-1",
+            "text-2",
+            "text-3",
+        ]
+
+    def test_search_page_zero_can_be_empty(self, client, notebook: Notebook):
+        """Test the first search page can represent an empty result set."""
+        client.api_response = search_response(
+            client,
+            total_found=0,
+            total_returned=0,
+        )
+
+        page = notebook.search("missing").page(0)
+
+        _ = client.pop_api_call()
+        assert page.page_number == 0
+        assert page.total_found == 0
+        assert page.total_returned == 0
+        assert page.entries == ()
+
+    def test_search_iteration_does_not_yield_empty_first_page(
+        self, client, notebook: Notebook
+    ):
+        """Test search iteration stops without yielding when no entries match."""
+        client.api_response = search_response(
+            client,
+            total_found=0,
+            total_returned=0,
+        )
+
+        pages = list(notebook.search("missing"))
+
+        _ = client.pop_api_call()
+        assert pages == []
+
+    def test_search_page_negative_index_raises(self, notebook: Notebook):
+        """Test search page indexes are non-negative."""
+        with pytest.raises(IndexError, match="non-negative"):
+            notebook.search("brown rat").page(-1)
+
+    def test_search_page_out_of_range_raises(self, client, notebook: Notebook):
+        """Test explicit search page access raises when the page is out of range."""
+        client.api_response = search_response(
+            client,
+            total_found=1,
+            total_returned=0,
+        )
+
+        with pytest.raises(IndexError, match="out of range"):
+            notebook.search("brown rat").page(1)
+
+        _ = client.pop_api_call()


### PR DESCRIPTION
## Summary
- Add Notebook.search() as a lazy entry search over the LabArchives entry_search endpoint.
- Return EntrySearchPage objects containing pagination counts and normal Entry instances.
- Document search-and-replace usage and cover pagination, parsing, empty results, IndexError behavior, and existing entry update behavior in tests.

## Validation
- uv run --python 3.10 pytest --no-cov
- uv run --python 3.10 ruff format --check .
- uv run --python 3.10 ruff check .
- uv run --python 3.10 pyright
- uv run --python 3.10 ty check --python-version 3.10
- uv run --python 3.10 sphinx-build -b html docs/source docs/_build/html

Closes #180