### PR TITLE
docs: fix 404 README doc links via a stable latest alias

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,6 +57,8 @@ jobs:
           fi
 
           touch docs/_build/html/.nojekyll
+          # Stable alias so deep links (e.g. from the README) survive releases.
+          cp -r "docs/_build/html/${latest}" docs/_build/html/latest
           cat > docs/_build/html/index.html <<EOF
           <!doctype html>
           <html lang="en">

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A Python client for the LabArchives API.
 
 ## Start Here
 
-- New to `labapi`? Follow the [First Success Tutorial](https://nimh-dsst.github.io/labapi/quick_start/tutorial.html) for the fastest path from install to a visible change in LabArchives.
-- Already using `labapi`? Jump to the [Quick Start](https://nimh-dsst.github.io/labapi/quick_start/index.html), [User Guide](https://nimh-dsst.github.io/labapi/guide/index.html), [Examples](https://nimh-dsst.github.io/labapi/examples/index.html), or [FAQ](https://nimh-dsst.github.io/labapi/faq.html).
+- New to `labapi`? Follow the [First Success Tutorial](https://nimh-dsst.github.io/labapi/latest/quick_start/tutorial.html) for the fastest path from install to a visible change in LabArchives.
+- Already using `labapi`? Jump to the [Quick Start](https://nimh-dsst.github.io/labapi/latest/quick_start/index.html), [User Guide](https://nimh-dsst.github.io/labapi/latest/guide/index.html), [Examples](https://nimh-dsst.github.io/labapi/latest/examples/index.html), or [FAQ](https://nimh-dsst.github.io/labapi/latest/faq.html).
 - Working on the package itself? Start with [CONTRIBUTING.md](https://github.com/nimh-dsst/labapi/blob/main/CONTRIBUTING.md).
 
 ## Install
@@ -139,12 +139,12 @@ page = notebook.traverse("Experiments/2026/Results")
 
 ## Documentation Map
 
-- [First Success Tutorial](https://nimh-dsst.github.io/labapi/quick_start/tutorial.html): shortest path from install to a successful write.
-- [Quick Start](https://nimh-dsst.github.io/labapi/quick_start/index.html): setup, navigation, page creation, uploads, and basic write operations.
-- [Authentication Guide](https://nimh-dsst.github.io/labapi/guide/auth.html): local browser auth, manual flows, and callback-based integration patterns.
-- [User Guide](https://nimh-dsst.github.io/labapi/guide/index.html): paths, entries, API behavior, exceptions, limits, and architecture notes.
-- [Examples](https://nimh-dsst.github.io/labapi/examples/index.html): end-to-end scripts for real workflows.
-- [FAQ](https://nimh-dsst.github.io/labapi/faq.html): troubleshooting and environment questions.
+- [First Success Tutorial](https://nimh-dsst.github.io/labapi/latest/quick_start/tutorial.html): shortest path from install to a successful write.
+- [Quick Start](https://nimh-dsst.github.io/labapi/latest/quick_start/index.html): setup, navigation, page creation, uploads, and basic write operations.
+- [Authentication Guide](https://nimh-dsst.github.io/labapi/latest/guide/auth.html): local browser auth, manual flows, and callback-based integration patterns.
+- [User Guide](https://nimh-dsst.github.io/labapi/latest/guide/index.html): paths, entries, API behavior, exceptions, limits, and architecture notes.
+- [Examples](https://nimh-dsst.github.io/labapi/latest/examples/index.html): end-to-end scripts for real workflows.
+- [FAQ](https://nimh-dsst.github.io/labapi/latest/faq.html): troubleshooting and environment questions.
 
 ## Development
 


### PR DESCRIPTION
The README's documentation deep links (e.g. `/labapi/quick_start/tutorial.html`) return 404: the Pages deploy (`sphinx-multiversion`) publishes pages only under versioned `/vX.Y.Z/` directories plus a root redirect, so unversioned paths never resolve.

Fix in two parts:

- `pages.yml`: copy the newest `vX.Y.Z` build to a stable `latest/` alias during deploy, so deep links survive releases without pinning a version.
- `README.md`: point the eight documentation deep links at `/labapi/latest/...`. The bare `/labapi/` root link is untouched (the existing redirect handles it), as are the GitHub blob links.

Note: `/latest/` goes live on the next Pages run — either the `v1.1.0` tag push or a manual `workflow_dispatch` of the Pages workflow after this merges. Until then the links 404 exactly as before; no regression.

Same fix is included on the `1.1` branch via #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #186
