### PR TITLE
docs: mirror 1.1.1 changelog and cryptography floor to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ This changelog is written for package users and maintainers, so entries call
 out user-visible behavior, supported runtime changes, and release-engineering
 details that affect development workflows.
 
+## 1.1.1 - 2026-07-05
+
+### Fixed
+
+- Fixed README documentation links that returned 404 by publishing a stable
+  `latest/` docs alias alongside the versioned directories.
+- Corrected documentation errors: the `enumerate_all()` depth example,
+  `create(parents=False)` raising `ValueError` for any multi-segment path, the
+  exception hierarchy (`PathError`, `ExtractionError`, `TreeChildParseError`),
+  `User.notebooks` caching, the scope of `strict_cert=False` (relaxes strict
+  X.509 validation only, not certificate verification), the folder-download
+  output layout diagram, and `UnknownEntry` vs `UnimplementedEntry` wrapping.
+
+### Changed
+
+- Expanded documentation: full `Notebook.search()` coverage (lazy
+  `EntrySearch`, zero-based `page()` access, result-page metadata) and a new
+  "Obtain API Keys" section.
+- Copy-edited the documentation and public docstrings for precision and
+  concision.
+
+### Security
+
+- Raised the minimum `cryptography` requirement to 48.0.1 and updated the
+  locked version, dropping wheels that bundle a vulnerable OpenSSL
+  (Dependabot alert 15).
+
 ## 1.1.0 - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "cryptography>=46.0.3",
+    "cryptography>=48.0.1",
     "lxml>=6.0.2",
     "requests>=2.32.5",
     "typing-extensions>=4.12.2",

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=46.0.3" },
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "installed-browsers", marker = "extra == 'builtin-auth'", specifier = ">=0.1.5" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "python-dotenv", marker = "extra == 'dotenv'", specifier = ">=1.2.1" },


### PR DESCRIPTION
Mirror of the 1.1.1 release prep (#190) so main stays a superset:

- Add the 1.1.1 CHANGELOG section, byte-identical to the one on the `1.1` branch.
- Raise `cryptography>=48.0.1` in `pyproject.toml` (main already has the lock bump from #188; without the floor, the next release cut from main would silently drop the security guarantee 1.1.1 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)