### PR TITLE
[codex] mirror 1.1 documentation refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A Python client for the LabArchives API.
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19599400.svg)](https://doi.org/10.5281/zenodo.19599400)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
-`labapi` helps you authenticate with LabArchives, navigate notebook trees, and create or update notebook content from Python.
+`labapi` authenticates with LabArchives, navigates notebook trees, and creates or updates notebook content from Python.
 
 [Source](https://github.com/nimh-dsst/labapi) | [Docs](https://nimh-dsst.github.io/labapi/) | [Issues](https://github.com/nimh-dsst/labapi/issues)
 
 ## Start Here
 
-- New to `labapi`? Follow the [First Success Tutorial](https://nimh-dsst.github.io/labapi/latest/quick_start/tutorial.html) for the fastest path from install to a visible change in LabArchives.
+- New to `labapi`? Follow the [First Success Tutorial](https://nimh-dsst.github.io/labapi/latest/quick_start/tutorial.html) to install `labapi`, authenticate, and create your first LabArchives entry.
 - Already using `labapi`? Jump to the [Quick Start](https://nimh-dsst.github.io/labapi/latest/quick_start/index.html), [User Guide](https://nimh-dsst.github.io/labapi/latest/guide/index.html), [Examples](https://nimh-dsst.github.io/labapi/latest/examples/index.html), or [FAQ](https://nimh-dsst.github.io/labapi/latest/faq.html).
 - Working on the package itself? Start with [CONTRIBUTING.md](https://github.com/nimh-dsst/labapi/blob/main/CONTRIBUTING.md).
 
@@ -52,6 +52,8 @@ Extras:
 - `builtin-auth` enables `default_authenticate()` to open the LabArchives login flow in a local browser.
 
 ## Configure Credentials
+
+LabArchives issues API keys on request. Ask your institution's LabArchives site administrator or Enterprise Success Team contact to request API access, or contact [support@labarchives.com](mailto:support@labarchives.com). LabArchives provides the Access Key ID, Access Password, and the API base URL for your region.
 
 Add your LabArchives API credentials to a `.env` file:
 
@@ -96,13 +98,6 @@ with Client() as client:
     page.entries.create(TextEntry, "<p>Hello from labapi!</p>")
 ```
 
-This is the recommended local workflow:
-
-1. Install `labapi[dotenv,builtin-auth]`.
-2. Set `API_URL`, `ACCESS_KEYID`, and `ACCESS_PWD`.
-3. Call `default_authenticate()` once the client is open.
-4. Start creating or updating notebooks, folders, pages, and entries through the object model.
-
 ## Common Tasks
 
 Authenticate in a service or callback-based app:
@@ -139,12 +134,12 @@ page = notebook.traverse("Experiments/2026/Results")
 
 ## Documentation Map
 
-- [First Success Tutorial](https://nimh-dsst.github.io/labapi/latest/quick_start/tutorial.html): shortest path from install to a successful write.
+- [First Success Tutorial](https://nimh-dsst.github.io/labapi/latest/quick_start/tutorial.html): install, authenticate, and create a first entry.
 - [Quick Start](https://nimh-dsst.github.io/labapi/latest/quick_start/index.html): setup, navigation, page creation, uploads, and basic write operations.
-- [Authentication Guide](https://nimh-dsst.github.io/labapi/latest/guide/auth.html): local browser auth, manual flows, and callback-based integration patterns.
+- [Authentication Guide](https://nimh-dsst.github.io/labapi/latest/guide/auth.html): browser authentication, terminal/manual authentication, and callback URL authentication.
 - [User Guide](https://nimh-dsst.github.io/labapi/latest/guide/index.html): paths, entries, API behavior, exceptions, limits, and architecture notes.
-- [Examples](https://nimh-dsst.github.io/labapi/latest/examples/index.html): end-to-end scripts for real workflows.
-- [FAQ](https://nimh-dsst.github.io/labapi/latest/faq.html): troubleshooting and environment questions.
+- [Examples](https://nimh-dsst.github.io/labapi/latest/examples/index.html): scripts for JSON sync, folder export, and CSV table updates.
+- [FAQ](https://nimh-dsst.github.io/labapi/latest/faq.html): authentication, certificate, and environment troubleshooting.
 
 ## Development
 

--- a/docs/source/examples/csv_table.rst
+++ b/docs/source/examples/csv_table.rst
@@ -3,21 +3,14 @@
 CSV Table Upload/Download
 =========================
 
-This example uploads CSV data as rich-text HTML tables in LabArchives and can
-download those tables back to CSV later. It is a good fit when you want
-readable tables in the notebook UI without losing a machine-friendly export
-path.
+This example uploads a CSV file as a LabArchives rich-text HTML table and
+downloads table entries back to CSV.
 
 When to Use It
 --------------
 
-This is useful for:
-
-- Uploading experimental data tables for visual display in notebooks.
-- Creating formatted data tables that stay readable in the web interface.
-- Extracting tabular data back to CSV for downstream analysis.
-- Documenting datasets with consistent structure.
-- Sharing tables with collaborators in a readable format.
+Use it to publish CSV results in notebook pages and retrieve table entries for
+downstream analysis.
 
 Requirements
 ------------
@@ -44,9 +37,8 @@ You can also provide the same values through shell environment variables. See
 How It Works
 ------------
 
-The example is a single script. ``examples/csv_table/csv_table.py`` defines
-small typed option objects, uses LabArchives page and entry APIs, and keeps
-CSV/HTML conversion details inside the script.
+``examples/csv_table/csv_table.py`` defines typed upload/download options,
+converts CSV rows to HTML table markup, and parses table entries back to CSV.
 
 Upload Flow
 ~~~~~~~~~~~
@@ -78,19 +70,19 @@ Upload the checked-in sample CSV file:
 
    uv run python csv_table.py upload sample_data.csv "Experiments/Results" --notebook "My Notebook"
 
-Upload a CSV file with every row treated as table data:
+Upload a CSV file without treating the first row as a header:
 
 .. code-block:: bash
 
    uv run python csv_table.py upload sample_data.csv "Experiments/Results" --notebook "My Notebook" --no-header
 
-Download the most recent table from a page:
+Download the newest text entry on a page that contains an HTML table:
 
 .. code-block:: bash
 
    uv run python csv_table.py download "Experiments/Results" results.csv --notebook "My Notebook"
 
-Download a specific table entry by index:
+Download a table from a specific zero-based page entry index:
 
 .. code-block:: bash
 
@@ -143,20 +135,17 @@ The script will generate this HTML table:
      </tbody>
    </table>
 
-The table is displayed with LabArchives' default styling.
-
 Notes and Limitations
 ---------------------
 
-- Tables are uploaded as rich-text entries, making them readable in the
-  LabArchives web interface.
 - Tables are rendered with LabArchives' default styling and no inline CSS.
-- The script preserves table structure and can round-trip CSV to HTML and back
-  to CSV.
-- Multiple tables on one page are supported; by default, the download uses the
-  most recent table.
+- For simple tables, rows and columns are preserved when converting CSV to
+  HTML and back; leading and trailing whitespace inside cells is stripped on
+  download.
+- Multiple table entries on one page are supported; by default, download
+  selects the newest text entry containing a table.
 - Empty cells in CSV files are preserved in the HTML table.
-- CSV files with special characters should use UTF-8 encoding.
+- Save non-ASCII CSV files as UTF-8.
 - Complex nested tables are not supported.
 - Only the first table is extracted if an entry contains multiple tables.
 
@@ -170,8 +159,8 @@ Ways to Extend It
 5. Generate charts from CSV data and upload them as images.
 6. Support HTML table captions.
 
-Source
-------
+Source Code
+-----------
 
 .. literalinclude:: ../../../examples/csv_table/csv_table.py
    :language: python

--- a/docs/source/examples/folder_download.rst
+++ b/docs/source/examples/folder_download.rst
@@ -3,20 +3,15 @@
 Folder Structure Download
 =========================
 
-This example downloads a LabArchives notebook subtree to your local computer
-while preserving its directory hierarchy. Pages become folders, and individual
+This example exports a notebook, folder, or page to local directories.
+LabArchives directories and pages become local directories, and individual
 entries are written out as separate files.
 
 When to Use It
 --------------
 
-This is useful for:
-
-- Creating local backups of your LabArchives notebooks.
-- Exporting notebook content for offline viewing.
-- Archiving completed projects.
-- Migrating content to other systems.
-- Version control integration for notebook content.
+Use it to create local backup, offline review, archival, migration, or
+version-control copies of notebook content.
 
 Requirements
 ------------
@@ -65,9 +60,9 @@ Overwrite an existing output directory:
 How It Works
 ------------
 
-``examples/folder_download/folder_download.py`` contains importable download
-functions plus a command-line wrapper. The reusable layer takes an authenticated
-``User`` and returns a ``DownloadResult`` instead of printing or exiting.
+``examples/folder_download/folder_download.py`` exposes
+``download_notebook_or_folder(user, options)``, which writes the export and
+returns a ``DownloadResult`` for callers.
 
 The script mirrors the LabArchives structure:
 
@@ -75,7 +70,7 @@ The script mirrors the LabArchives structure:
 
    LabArchives Structure:          Local File Structure:
 
-   My Notebook/                    output/
+   My Notebook/                    output/My Notebook/
    |- Experiments/                 |- Experiments/
    |  |- Trial 1/  (page)          |  |- Trial 1/
    |  |  |- Header entry           |  |  |- 001_header.txt
@@ -103,12 +98,13 @@ Downloaded entries follow this naming pattern:
 - Entries are numbered in the order they appear on the page.
 - Entry type is indicated in the filename.
 - Attachments preserve their original filename.
-- Captions are saved in separate ``*_caption.txt`` files.
+- When an attachment has a caption, it is saved in a separate
+  ``*_caption.txt`` file.
 
 Output Layout
 -------------
 
-Each downloaded location contains:
+The exported tree uses these files and subdirectories:
 
 For pages:
 
@@ -117,26 +113,21 @@ For pages:
 
 For directories:
 
-- Subdirectories for each child directory.
-- Subdirectories for each page.
+- A subdirectory for each child directory or page.
 
 Notes
 -----
 
-- The script preserves the complete directory structure.
 - Filenames are sanitized to be filesystem-safe.
-- Widget entries are noted but cannot be fully exported because they are
-  read-only.
-- Large notebooks may take significant time to download.
-- The script creates a ``_metadata.txt`` file for each page with additional
-  information.
+- Widget entries are exported as ``*_widget.txt`` placeholder notes; their
+  content is not exported.
+- Download time grows with notebook size and attachment count.
 
 Reusable API
 ------------
 
-When building your own script, import the download function and call it
-directly. Most scripts only need ``DownloadFolderOptions`` and
-``download_notebook_or_folder``.
+Reuse the exporter by constructing ``DownloadFolderOptions`` and passing it to
+``download_notebook_or_folder``:
 
 .. code-block:: python
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -3,9 +3,9 @@
 Example Applications
 ====================
 
-These runnable examples show end-to-end workflows built on top of the core
-``labapi`` APIs. Start with :ref:`installation` if you still need to set up the
-recommended local interactive profile.
+These examples show complete scripts for JSON sync, folder export, and CSV
+table conversion. Start with :ref:`installation` if you still need to set up
+the recommended local interactive profile.
 
 .. toctree::
    :maxdepth: 1
@@ -25,27 +25,16 @@ Example Matrix
      - Best For
      - Extra Packages
    * - :doc:`json_sync`
-     - Syncing JSON attachments and previews between a local folder and a
-       LabArchives page
+     - Uploading JSON files to a page and downloading JSON attachments back to
+       disk
      - none
    * - :doc:`folder_download`
-     - Exporting notebook structure to local files for backup, review, or
-       archival
+     - Exporting notebook pages and entries to local files for backup or
+       review
      - none
    * - :doc:`csv_table`
-     - Converting CSV data to LabArchives HTML tables and round-tripping back
-       to CSV
+     - Converting CSV data to LabArchives HTML tables and back to CSV
      - ``beautifulsoup4``
-
-Published Examples
-------------------
-
-- :doc:`json_sync` synchronizes JSON files between a local folder and a single
-  LabArchives page.
-- :doc:`folder_download` mirrors a notebook subtree to local files while
-  preserving page and directory structure.
-- :doc:`csv_table` uploads CSV data as HTML tables and downloads those tables
-  back to CSV.
 
 Getting Started
 ---------------
@@ -55,11 +44,11 @@ All published examples assume:
 - Python 3.10+.
 - The recommended local interactive profile:
   ``labapi[dotenv,builtin-auth]``.
-- A repository-root working directory when you run the ``uv run --project ...``
-  commands below.
-- Notebook-relative page paths paired with ``--notebook "My Notebook"``.
+- Run the ``uv run --project ...`` commands below from the repository root.
+- Use page paths relative to the notebook root, together with
+  ``--notebook "My Notebook"``.
 
-Use these sample commands as known-good starting points:
+Use these sample commands as starting points:
 
 .. code-block:: bash
 
@@ -71,8 +60,8 @@ Additional Local Examples
 -------------------------
 
 The repository also includes ``examples/model_logging`` and
-``examples/notebook_logging``. They are maintained alongside the published
-examples above, but do not yet have dedicated Sphinx pages.
+``examples/notebook_logging``. They are maintained in the repository but are
+not covered by these Sphinx example pages.
 
 Related Pages
 -------------

--- a/docs/source/examples/json_sync.rst
+++ b/docs/source/examples/json_sync.rst
@@ -3,19 +3,14 @@
 JSON Folder Sync
 ================
 
-This example syncs JSON content between a local folder and a LabArchives page.
-Use it when you want a simple batch workflow for moving structured JSON files
-in or out of a notebook page.
+This example uploads local ``*.json`` files to a LabArchives page and downloads
+JSON attachment entries back to disk.
 
 When to Use It
 --------------
 
-This is useful for:
-
-- Backing up structured data from LabArchives to your local machine.
-- Uploading batches of JSON data files to a LabArchives page.
-- Syncing experimental data stored as JSON between local files and LabArchives.
-- Archiving API responses or other structured datasets.
+Use it to upload batches of JSON files, export JSON attachments for backup, or
+archive JSON API responses.
 
 Requirements
 ------------
@@ -60,17 +55,18 @@ How It Works
 
 - JSON files are uploaded with
   :meth:`~labapi.entry.collection.Entries.create_json_entry`.
-- ``examples/json_sync/json_sync.py`` contains importable upload and download
-  functions plus a command-line ``main()`` guarded by the usual
-  ``if __name__ == "__main__"`` check.
+- ``examples/json_sync/json_sync.py`` exposes importable upload and download
+  functions and a CLI entry point.
 - Each upload creates a JSON attachment with ``application/json`` MIME type and
   a companion rich-text preview entry.
-- Download mode writes each JSON attachment back to a local ``.json`` file.
+- Download mode writes each JSON attachment back to a local file named after
+  the attachment.
 
 Reusable API
 ------------
 
-When building your own script, import the sync function and call it directly:
+When building your own script, import ``upload_json_files`` and call it
+directly:
 
 .. code-block:: python
 
@@ -96,10 +92,9 @@ Notes and Limitations
 
 - Invalid JSON files are skipped with an error message.
 - The script creates the output folder if it does not exist during download.
-- The reusable functions return a ``FileResult`` for each file they try to sync.
+- The reusable functions return a ``FileResult`` for each JSON file processed,
+  including failures.
 - The CLI handles terminal output and process exit codes.
-- The sample upload command uses the checked-in files under
-  ``examples/json_sync/sample_data``.
 
 Ways to Extend It
 -----------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,9 +3,6 @@
 Frequently Asked Questions
 ==========================
 
-This page collects the operational questions that come up most often when
-configuring authentication and troubleshooting local API access.
-
 How Do I Choose Which Browser ``default_authenticate()`` Opens?
 ---------------------------------------------------------------
 
@@ -20,15 +17,9 @@ tries to open a compatible local browser automatically. Set the
    export LA_AUTH_BROWSER=edge
    export LA_AUTH_BROWSER=terminal
 
-Supported values:
-
-- ``chrome`` for Google Chrome.
-- ``firefox`` for Mozilla Firefox.
-- ``edge`` for Microsoft Edge.
-- ``terminal`` to print the URL for manual copy/paste.
-
-If ``LA_AUTH_BROWSER`` is not set, ``labapi`` falls back to automatic browser
-detection.
+Supported values are ``chrome``, ``firefox``, ``edge``, and ``terminal``;
+``terminal`` prints the URL for manual copy/paste instead of opening a
+browser.
 
 Example:
 
@@ -47,13 +38,13 @@ How Do I Handle SSL/TLS Certificate Issues?
 -------------------------------------------
 
 By default, :class:`~labapi.client.Client` verifies TLS certificates on every
-HTTPS request. Keep that default whenever possible.
+HTTPS request.
 
 Can I Disable Strict Certificate Verification?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In some environments, such as corporate networks with custom CA certificates
-or local test systems, you may need to disable strict verification temporarily:
+For short-lived tests against systems whose certificates fail strict
+validation, pass ``strict_cert=False``:
 
 .. code-block:: python
 
@@ -67,15 +58,15 @@ or local test systems, you may need to disable strict verification temporarily:
    )
 
 .. warning::
-   Disabling certificate verification (``strict_cert=False``) can expose you
-   to man-in-the-middle attacks. Only use it in trusted environments where you
-   understand the security tradeoff.
+   Relaxing strict X.509 validation (``strict_cert=False``) can expose you
+   to man-in-the-middle attacks. Do not use this for normal production API
+   traffic or on networks you do not control.
 
 How Do I Trust a Custom CA Bundle Instead?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If your environment uses a private Certificate Authority, prefer adding that
-CA to a trusted bundle instead of turning verification off entirely.
+CA to a trusted bundle instead of relaxing strict certificate validation.
 
 Find the active ``certifi`` bundle with:
 
@@ -102,8 +93,9 @@ What Should I Check When Authentication Fails?
 When the authentication flow fails or stalls, check these common causes:
 
 1. Verify that ``ACCESS_KEYID`` and ``ACCESS_PWD`` are set correctly.
-2. If the browser does not open, confirm ``LA_AUTH_BROWSER`` or install the
-   ``builtin-auth`` extra.
+2. If the browser does not open, set ``LA_AUTH_BROWSER=terminal`` for manual
+   authentication, or install the ``builtin-auth`` extra for browser
+   launching.
 3. If you see certificate errors, use the guidance above to trust your CA
    bundle.
 4. If you use :meth:`~labapi.client.Client.generate_auth_url`, make sure the

--- a/docs/source/guide/api_calls.rst
+++ b/docs/source/guide/api_calls.rst
@@ -8,8 +8,8 @@ high-level wrapper in ``labapi``. The examples below assume you already have an
 authenticated ``user`` object; see :ref:`first_calls` or :ref:`auth` if you
 need to establish a session first.
 
-Choose an API Access Level
---------------------------
+Choose a Call Path
+------------------
 
 .. list-table::
    :header-rows: 1
@@ -33,11 +33,11 @@ Choose an API Access Level
 Use the User Object
 -------------------
 
-The easiest way to make arbitrary calls is through
-:class:`~labapi.user.User`. Its
-:meth:`~labapi.user.User.api_get` and
-:meth:`~labapi.user.User.api_post` methods automatically include your User ID
-(``uid``) and handle request signing.
+For XML endpoints that need the current user ID, call
+:meth:`~labapi.user.User.api_get` or
+:meth:`~labapi.user.User.api_post` on :class:`~labapi.user.User`. These
+methods automatically include your User ID (``uid``) and handle request
+signing.
 
 .. code-block:: python
 
@@ -47,7 +47,7 @@ The easiest way to make arbitrary calls is through
 Parsing XML Responses
 ---------------------
 
-Because the LabArchives API returns XML, ``labapi`` uses ``lxml`` for parsing.
+For XML API responses, ``labapi`` uses ``lxml`` for parsing.
 You can work with the returned element directly or use
 :func:`~labapi.util.extract.extract_etree` for structured extraction.
 
@@ -75,7 +75,7 @@ Using ``extract_etree``
 Raw and Streaming Responses
 ---------------------------
 
-For more control, or when dealing with non-XML data, use the lower-level
+When you need response metadata, raw bytes, or streaming, use the lower-level
 :class:`~labapi.client.Client` methods directly.
 
 Raw Responses
@@ -114,8 +114,9 @@ iterable and a context manager:
 Constructing Signed URLs
 ------------------------
 
-Use :meth:`~labapi.client.Client.construct_url` when you need a signed URL for
-another tool, such as a browser download or a service-to-service handoff.
+Use :meth:`~labapi.client.Client.construct_url` when code outside ``labapi``
+needs to make the signed request, such as a browser download or a
+service-to-service handoff.
 
 .. code-block:: python
 

--- a/docs/source/guide/architecture.rst
+++ b/docs/source/guide/architecture.rst
@@ -69,8 +69,8 @@ successful API calls.
 Utility Layer Boundary
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The ``labapi.util`` package provides shared primitives that keep core modules
-small and predictable:
+The ``labapi.util`` package provides primitives that are shared by tree,
+entry, and client modules:
 
 * :class:`~labapi.util.path.NotebookPath` path normalization/resolution
 * typed index markers (``Index.Id``/``Index.Name``)
@@ -94,8 +94,8 @@ first access:
   ``_children`` and resets ``_populated=False``.
 
 .. note::
-   While ``_populated`` is true, read APIs for that container should be served
-   from local ``_children`` without another tree-level API call.
+   While ``_populated`` is true, read APIs for that container use local
+   ``_children`` without another tree-level API call.
 
 Page Entries Cache (``_entries``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +109,7 @@ Page Entries Cache (``_entries``)
   ``None``.
 
 .. note::
-   Repeated ``page.entries`` access should return the same
+   Repeated ``page.entries`` access returns the same
    :class:`~labapi.entry.collection.Entries` object until refresh.
 
 Path Cache (``_has_path``)
@@ -201,8 +201,9 @@ When to Call Refresh
 ~~~~~~~~~~~~~~~~~~~~
 
 Use :meth:`~labapi.tree.mixins.AbstractTreeContainer.refresh` (or
-:meth:`~labapi.tree.page.NotebookPage.refresh` for page entries) when external
-changes may have occurred or when you need to force a re-fetch.
+:meth:`~labapi.tree.page.NotebookPage.refresh` for page entries) before reading
+changes made by another user, the web UI, or another API session, or when you
+need to force a re-fetch.
 
 Current behavior is intentionally shallow:
 
@@ -215,22 +216,18 @@ Other Entry Types
 -----------------
 
 
-When page entries are loaded, recognized-but-unimplemented and fully unknown types are
-wrapped as :class:`~labapi.entry.entries.unknown.UnknownEntry` with warnings in
+When page entries are loaded, unrecognized part types are wrapped as
+:class:`~labapi.entry.entries.unknown.UnknownEntry` and
+recognized-but-unimplemented types as
+:class:`~labapi.entry.entries.unknown.UnimplementedEntry`, with warnings in
 :attr:`~labapi.tree.page.NotebookPage.entries`.
 
-Known Shortcuts and TODO Areas
-------------------------------
+Known Limitations and TODOs
+---------------------------
 
-These are current incomplete areas that contributors should treat carefully:
-
-* container refresh clears the owner's child cache, but detached child objects
-  held elsewhere are not reconciled in place
-* page refresh clears the page-level entries cache, but existing entry objects
-  are not invalidated in place
 * individual entry deletion is not implemented
-* ``create_json_entry()`` still creates two concrete entries and does not yet
-  model that pair as one logical unit
+* ``create_json_entry()`` creates an ``AttachmentEntry`` and a ``TextEntry``;
+  no wrapper object represents the pair
 
 Contributor Checklist for Internal Changes
 ------------------------------------------

--- a/docs/source/guide/auth.rst
+++ b/docs/source/guide/auth.rst
@@ -4,14 +4,15 @@
 Authentication
 ==============
 
-At a high level, authentication is handled by LabArchives. ``labapi`` works with two input patterns:
+Authentication is handled by LabArchives. ``labapi`` works with two input patterns:
 
 - callback-based authentication, where LabArchives redirects back with
   ``email`` and ``auth_code``
 - manually copied External App credentials from the LabArchives UI
 
-Both can be completed through :meth:`~labapi.client.Client.login`. The callback
-flow is generally the better default because it also works with SSO.
+Use :meth:`~labapi.client.Client.login` for either pattern. Prefer
+callback-based authentication for user sign-ins, especially when SSO is
+required.
 
 Choosing an Auth Pattern
 ------------------------
@@ -26,21 +27,21 @@ Use the flow that matches where your code runs:
      - Why
    * - Local scripts, notebooks, ad-hoc analysis on a workstation
      - :meth:`~labapi.client.Client.default_authenticate`
-     - Fastest "happy path" and easiest onboarding.
+     - No callback wiring or manual credential copying; handles the browser round-trip automatically.
    * - Headless hosts (containers, CI workers, cron jobs, orchestrators)
      - :meth:`~labapi.client.Client.generate_auth_url` + callback handler + :meth:`~labapi.client.Client.login`
      - Avoids dependence on a local browser session.
    * - One-off/manual testing without callback wiring
      - :meth:`~labapi.client.Client.login` with External App credentials
-     - Useful for quick experiments when interactive callback flow is not available.
+     - Credentials are copied from the LabArchives UI; no browser or callback listener needed.
 
 Interactive Authentication
 --------------------------
 
-The most direct local workflow is
-:meth:`~labapi.client.Client.default_authenticate`. It launches or prints a
-LabArchives login URL, listens on a temporary local callback server, and then
-signs the user in immediately after the redirect completes.
+For local interactive use, call
+:meth:`~labapi.client.Client.default_authenticate`. It opens or prints a
+LabArchives login URL, starts a temporary local callback server, and logs in
+after LabArchives redirects back.
 
 .. note:: 
     When the :ref:`optional-deps` are installed, this method can open a
@@ -58,12 +59,12 @@ signs the user in immediately after the redirect completes.
 Server-Based Authentication
 ---------------------------
 
-For deeper integrations with other systems, or for use in servers, use
-:meth:`~labapi.client.Client.generate_auth_url`. It generates a LabArchives
-authentication URL that eventually redirects to the callback URL you pass in,
-letting your application handle credential capture on its own server.
+For web apps and service integrations, call
+:meth:`~labapi.client.Client.generate_auth_url` with your callback URL.
+LabArchives redirects to that callback with ``email`` and ``auth_code``, and
+your server passes those values to :meth:`~labapi.client.Client.login`.
 
-For service environments, this is the recommended flow:
+The flow:
 
 1. Your app exposes a callback URL (for example ``https://my-service.example.org/labarchives/callback``).
 2. Your app sends users to ``client.generate_auth_url(callback_url)``.
@@ -73,7 +74,7 @@ For service environments, this is the recommended flow:
 
 .. note::
    ``labapi`` currently does not provide a separate client-credentials style service principal flow.
-   Service integrations should use callback capture + :meth:`~labapi.client.Client.login` for user context, or External App authentication where operationally appropriate.
+   Service integrations should use callback-based login for user context. Use External App authentication only when the job can manage a short-lived External App auth code.
 
 
 Example Flask App
@@ -138,9 +139,9 @@ If you want to keep browser handling separate from callback capture, use
 Headless and CI Workflows
 -------------------------
 
-In non-interactive environments (CI, scheduled jobs, or batch workers), avoid :meth:`~labapi.client.Client.default_authenticate` because it expects a browser + local callback listener.
+In non-interactive environments (CI, scheduled jobs, or batch workers), avoid :meth:`~labapi.client.Client.default_authenticate` because it expects a browser and a local callback listener.
 
-Instead, use one-hour codes for job execution and use :meth:`~labapi.client.Client.login` directly:
+For scheduled jobs, pass a short-lived ``auth_code`` to :meth:`~labapi.client.Client.login` directly:
 
 .. code-block:: bash
 
@@ -174,13 +175,12 @@ Instead, use one-hour codes for job execution and use :meth:`~labapi.client.Clie
 Operational guidance for automation:
 
 - Treat ``auth_code`` values as secrets; keep them in your CI secret store rather than source control.
-- Prefer short-lived credentials and regular rotation.
-- Build your own refresh/re-auth step in orchestration when codes expire.
+- Prefer short-lived credentials, and define how the job obtains a new External App auth code before the current one expires.
 - Use least-privilege LabArchives users for automated jobs.
 
 Related Pages
 -------------
 
-* :ref:`first_calls` for the quickest path to sign in and run your first notebook operations.
+* :ref:`first_calls` to sign in and run your first notebook operations.
 * :ref:`faq` for browser selection and TLS troubleshooting during authentication.
 * :ref:`limitations`

--- a/docs/source/guide/clearing_cache.rst
+++ b/docs/source/guide/clearing_cache.rst
@@ -3,15 +3,16 @@
 Clearing Cache
 ==============
 
-The LabArchives API client caches various data to improve performance and reduce unnecessary API calls.
-However, there are situations where you may need to refresh this cached data to reflect changes made
-outside your current session.
+The LabArchives API client caches child-node lists and page-entry collections so repeated reads
+do not issue API calls. Call ``refresh()`` before reading changes made outside the current
+session.
 
-Refreshing Object Cache
------------------------
+Refreshing Tree and Entry Caches
+--------------------------------
 
 Tree nodes (notebooks, directories, and pages) provide a :meth:`~labapi.tree.mixins.AbstractBaseTreeNode.refresh`
-method that clears cached data and forces the object to re-fetch from the API on next access.
+method that clears cached children for containers or cached entries for pages, so the next
+property access fetches them again.
 
 Refreshing a Page
 ~~~~~~~~~~~~~~~~~
@@ -35,7 +36,7 @@ When you refresh a page, the cached entries are cleared:
 Refreshing a Directory or Notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Similarly, you can refresh directories and notebooks to reload their children:
+For directories and notebooks, ``refresh()`` clears cached children:
 
 .. code-block:: python
 
@@ -51,10 +52,10 @@ Similarly, you can refresh directories and notebooks to reload their children:
     # Next access gets fresh data
     children = directory.children  # Re-fetches from API
 
-When You Usually Do Not Need Refresh
-------------------------------------
+When Local Mutations Do Not Need Refresh
+----------------------------------------
 
-If you create, rename, move, or delete nodes through this client, the in-memory tree is updated immediately as part of the same operation. In those cases, you usually do not need to call ``refresh()`` just to observe your own change locally.
+Create, rename, move, and delete operations update the in-memory tree after the API call succeeds, so ``refresh()`` is not needed to see that operation's local result.
 
 This includes:
 
@@ -75,17 +76,10 @@ This includes:
     page.move_to(archive)
     print(page.parent is archive)  # True without refresh()
 
-Use ``refresh()`` when you need to pick up changes made outside the current object graph, such as edits from another user, the web UI, or a separate API session.
-
 When to Refresh Data
 --------------------
 
-You typically need to refresh cached data in these scenarios:
-
-1. **Collaborative environments**: When other users or processes may be modifying the notebook
-2. **Long-running scripts**: When your script runs for an extended period and you want to check for updates
-3. **After external changes**: When you've made changes through the web interface or another API session
-4. **Polling for changes**: When waiting for external processes to create or modify content
+Use ``refresh()`` when you need to pick up changes made by another user, the LabArchives web UI, or another API session.
 
 Example: Polling for New Entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,17 +103,16 @@ Example: Polling for New Entries
 
         time.sleep(30)  # Wait 30 seconds before checking again
 
-Important Limitations
----------------------
+Limitations
+-----------
 
 .. warning::
-    The current implementation of ``refresh()`` has some limitations:
+    ``refresh()`` does not update existing child-object references:
 
-    **Stale object references**: If you have stored references to child objects (pages, directories,
-    or entries) before calling ``refresh()``, those objects will **not** be automatically updated.
-    They will continue to use their old cached data.
+    **Stale object references**: Existing references to child pages, directories, or entries are
+    not replaced by ``refresh()`` and can keep stale cached data.
 
-    **Example of potential issue:**
+    **Example: stale entry reference**
 
     .. code-block:: python
 
@@ -133,8 +126,7 @@ Important Limitations
         # It wasn't invalidated by the refresh
         print(entry.content)  # May show stale data
 
-    **Best practice**: After calling ``refresh()``, re-fetch any child objects you need
-    instead of reusing old references:
+    After ``refresh()``, re-fetch child objects before reading them:
 
     .. code-block:: python
 
@@ -161,10 +153,11 @@ The following data is cached and will be cleared by ``refresh()``:
 * List of entries on the page
 * Entry content and metadata
 
-**Not cached (always fresh from API):**
+**Not cleared by refresh():**
 
 * User authentication state
-* Notebook metadata accessed through :class:`~labapi.user.User`
+* The :class:`~labapi.user.User` ``notebooks`` collection, which is built once at
+  login and is not affected by tree or page ``refresh()``
 
 Related Pages
 -------------

--- a/docs/source/guide/contributing.rst
+++ b/docs/source/guide/contributing.rst
@@ -127,7 +127,7 @@ GitHub Actions split the main quality gates into separate workflows under
 - docs
 - manual integration tests
 
-Keeping these commands green locally is the fastest way to avoid CI surprises.
+Run the same commands locally before pushing to catch failures before CI.
 
 Type System
 -----------
@@ -137,7 +137,8 @@ documentation. All new code should be fully type-annotated.
 
 Key conventions:
 
-- ``from __future__ import annotations`` is present in every module.
+- ``from __future__ import annotations`` is used in modules that rely on
+  forward references.
 - Generics are used throughout the entry system so callers get concrete return
   types without extra casting.
 - ``TYPE_CHECKING`` guards prevent circular imports while keeping type
@@ -147,8 +148,8 @@ Key conventions:
 - ``overload`` is used on ``__getitem__`` to express the different return
   types produced by different index kinds.
 
-The project targets Python 3.10+ and uses modern typing features where they
-improve clarity, with backports from ``typing_extensions`` where needed. Keep
+The project targets Python 3.10+; use typing features supported by Python 3.10
+or available from ``typing_extensions``. Keep
 source syntax compatible with Python 3.10; for example, prefer
 ``TypeVar``/``Generic`` over PEP 695 generic parameter syntax.
 
@@ -157,4 +158,4 @@ Related Pages
 
 - :ref:`architecture` for the current internal module and cache model.
 - :ref:`integration_design` for practical design guidance across the guide set.
-- :ref:`reference` for generated API signatures while you are working.
+- :ref:`reference` for generated API signatures.

--- a/docs/source/guide/entries.rst
+++ b/docs/source/guide/entries.rst
@@ -3,12 +3,12 @@
 Working with Entries
 ====================
 
-Entries are the fundamental building blocks of a LabArchives page. They contain the actual data, such as rich text, plain text, headers, file attachments, and widgets.
+A LabArchives page contains entries for rich text, plain text, headers, file attachments, and widgets.
 
 Accessing Entries
 -----------------
 
-You can access the entries of a :class:`~labapi.tree.page.NotebookPage` through its ``entries`` property. This property returns an :class:`~labapi.entry.collection.Entries` object, which behaves like a sequence of entries.
+A :class:`~labapi.tree.page.NotebookPage` exposes ``entries``, an :class:`~labapi.entry.collection.Entries` sequence.
 
 .. code-block:: python
 
@@ -28,8 +28,10 @@ Searching Entries
 -----------------
 
 Use :meth:`~labapi.tree.notebook.Notebook.search` to search entries in a
-notebook. Search returns an iterable of result pages, and each page contains
-normal entry objects.
+notebook. It returns an :class:`~labapi.tree.search.EntrySearch`, a lazy,
+iterable sequence of result pages — no API request is made until you iterate
+it or fetch a specific page. Each page contains the same entry classes used by
+``page.entries``.
 
 .. code-block:: python
 
@@ -43,20 +45,41 @@ normal entry objects.
                    "Rattus norvegicus",
                )
 
+Iteration fetches consecutive pages until every match has been returned, and
+yields nothing when there are no matches.
+
+Each result page is an :class:`~labapi.tree.search.EntrySearchPage` that
+carries the matched entries along with result metadata. You can also fetch a
+single page on demand with :meth:`~labapi.tree.search.EntrySearch.page`
+instead of iterating:
+
+.. code-block:: python
+
+   search = notebook.search("Rattus norvegicus")  # page_size defaults to 25
+
+   first_page = search.page(0)  # page numbers are zero-based
+   print(f"{first_page.total_found} matching entries in the notebook")
+   print(f"{first_page.total_returned} entries on this page")
+
+:meth:`~labapi.tree.search.EntrySearch.page` raises :class:`IndexError` for
+negative or out-of-range page numbers, and
+:meth:`~labapi.tree.notebook.Notebook.search` raises :class:`ValueError` if
+``page_size`` is not positive.
+
 The search request itself is read-only. Returned entries use the same
 ``content`` accessors and setters as entries loaded from ``page.entries``.
 
 Entry Types
 -----------
 
-LabArchives supports several entry types. In ``labapi``, each type is represented by a specific class inheriting from :class:`~labapi.entry.entries.base.Entry`.
+LabArchives supports several entry types. In ``labapi``, each type is represented by a class inheriting from :class:`~labapi.entry.entries.base.Entry`.
 
 Text-based Entries
 ~~~~~~~~~~~~~~~~~~
 
 Text-based entries store their content as strings.
 
-* **Rich Text Entry** (:class:`~labapi.entry.entries.text.TextEntry`): Used for formatted text, typically HTML. Content type: ``"text entry"``. See `MDN HTML documentation <https://developer.mozilla.org/en-US/docs/Web/HTML>`_ for supported markup patterns.
+* **Rich Text Entry** (:class:`~labapi.entry.entries.text.TextEntry`): Used for formatted text, typically HTML. Content type: ``"text entry"``. See `MDN HTML documentation <https://developer.mozilla.org/en-US/docs/Web/HTML>`_ for HTML syntax.
 * **Plain Text Entry** (:class:`~labapi.entry.entries.text.PlainTextEntry`): Used for unformatted, raw text. Content type: ``"plain text entry"``.
 * **Header Entry** (:class:`~labapi.entry.entries.text.HeaderEntry`): Used for headings or titles within a page. Content type: ``"heading"``.
 
@@ -92,17 +115,19 @@ Widget Entries
 Widget entries (:class:`~labapi.entry.entries.widget.WidgetEntry`) embed interactive content or external applications. Like text entries, their content is represented as a string (often JSON or HTML).
 
 .. note::
-   Widget entries are currently read-only in ``labapi``. Their ``content`` property returns the widget's internal data as a JSON-formatted string.
+   Widget entries are currently read-only in ``labapi``.
 
-If LabArchives returns an entry type that ``labapi`` does not model yet,
-:attr:`~labapi.tree.page.NotebookPage.entries` wraps it as
-:class:`~labapi.entry.entries.unknown.UnknownEntry` and emits a warning instead
-of silently dropping it.
+If LabArchives returns an entry type that ``labapi`` does not model,
+:attr:`~labapi.tree.page.NotebookPage.entries` wraps unrecognized part types as
+:class:`~labapi.entry.entries.unknown.UnknownEntry` and
+recognized-but-unimplemented types as
+:class:`~labapi.entry.entries.unknown.UnimplementedEntry`, each with a warning,
+instead of silently dropping them.
 
 Creating New Entries
 --------------------
 
-You can create new entries using the :meth:`~labapi.entry.collection.Entries.create` method.
+Call :meth:`~labapi.entry.collection.Entries.create` to add an entry to a page.
 
 .. code-block:: python
 
@@ -120,7 +145,7 @@ You can create new entries using the :meth:`~labapi.entry.collection.Entries.cre
 Creating Attachments
 ~~~~~~~~~~~~~~~~~~~~
 
-To create an attachment entry, you first need to create an :class:`~labapi.entry.attachment.Attachment` object.
+Create an :class:`~labapi.entry.attachment.Attachment` object, then pass it to :meth:`~labapi.entry.collection.Entries.create`.
 
 .. code-block:: python
 
@@ -149,7 +174,7 @@ random-access binary file object.
 Working with JSON Data
 ----------------------
 
-A common pattern is to store structured data as a JSON attachment with a formatted preview in a companion text entry. The :meth:`~labapi.entry.collection.Entries.create_json_entry` method simplifies this.
+A common pattern is to store structured data as a JSON attachment with a formatted preview in a companion text entry. :meth:`~labapi.entry.collection.Entries.create_json_entry` creates both in one call.
 
 .. code-block:: python
 
@@ -165,14 +190,14 @@ A common pattern is to store structured data as a JSON attachment with a formatt
 Modifying Entries
 -----------------
 
-To modify an entry, simply set its ``content`` property. The change is automatically synchronized with the LabArchives server.
+Assigning to ``entry.content`` sends an update request to LabArchives. Unknown, unimplemented, and widget entries do not support updates and raise :class:`NotImplementedError`.
 
 .. code-block:: python
 
    entry = page.entries[0]
    entry.content = "New content for the entry"
 
-For attachments, setting the ``content`` property with a new :class:`~labapi.entry.attachment.Attachment` object will update the file.
+For attachments, assign a new :class:`~labapi.entry.attachment.Attachment` to ``attachment_entry.content`` to replace the uploaded file.
 
 .. code-block:: python
 

--- a/docs/source/guide/exceptions.rst
+++ b/docs/source/guide/exceptions.rst
@@ -3,7 +3,7 @@
 Exception Types
 ===============
 
-``labapi`` exposes a small set of public exception classes at the top level so
+``labapi`` exports its public exception classes at the package top level so
 callers can reliably catch failures by category.
 
 Public Exception Hierarchy
@@ -19,7 +19,12 @@ All custom exceptions inherit from
        |-- AuthenticationError
        |-- ApiError
        |-- NodeExistsError
+       |-- PathError
        `-- TraversalError
+
+``ExtractionError`` (which also inherits from :class:`ValueError`) and its
+subclass ``TreeChildParseError`` also exist but are not exported at the
+package top level; import them from ``labapi.exceptions``.
 
 Import and catch these from ``labapi``:
 
@@ -46,8 +51,8 @@ Common Operations and Raised Exceptions
    node with
    ``if_exists=InsertBehavior.Raise``.
 
-   Raises :class:`ValueError` when creating a multi-segment path without
-   ``parents=True`` and an intermediate parent is missing.
+   Raises :class:`ValueError` for any multi-segment path when
+   ``parents=False``, even if the intermediate directories exist.
 
 :meth:`~labapi.tree.mixins.AbstractBaseTreeNode.traverse`
    Raises :class:`~labapi.exceptions.TraversalError` when an intermediate path
@@ -58,4 +63,4 @@ Related Pages
 
 - :ref:`paths` for traversal rules and parent-navigation behavior.
 - :ref:`creating_pages` for duplicate-create behavior in practice.
-- :ref:`limitations` for broader operational caveats.
+- :ref:`limitations` for limitations not represented as exception types.

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -4,7 +4,7 @@ User Guide
 ==========
 
 The guide explains the behavior behind the quick-start examples and highlights
-the caveats that matter in real integrations. Start with the core usage pages,
+the known caveats. Start with the core usage pages,
 then move into the design notes if you are extending or contributing to
 ``labapi``.
 

--- a/docs/source/guide/index_access.rst
+++ b/docs/source/guide/index_access.rst
@@ -22,8 +22,8 @@ Supported Collection Types
   :class:`~labapi.tree.directory.NotebookDirectory`
 
 .. warning::
-   Page ``Entries`` do not support ``Index``. Access entries by integer index
-   or iteration instead.
+   Page ``Entries`` do not support ``Index`` slicing. Access entries by
+   integer index, iteration, or entry ID string.
 
 .. note::
    Iterating over ``user.notebooks`` or a tree container yields names. Use
@@ -39,14 +39,14 @@ By default, a string key looks up the first item with that name:
    notebook = user.notebooks["My Research Notebook"]
    experiments = notebook["Experiments"]
 
-If you need duplicate-preserving results, use ``all_keys()``, ``all_items()``,
-and ``all_values()`` on the collection instead of plain mapping helpers.
+If you need duplicate-preserving results, call ``all_keys()``, ``all_items()``,
+or ``all_values()`` instead of ``keys()``, ``items()``, or ``values()``.
 
 Explicit Indexing with ``Index``
 --------------------------------
 
-Use :class:`~labapi.util.types.Index` when you want to say whether you are
-looking up by ID or by name.
+Use :class:`~labapi.util.types.Index` to choose ID lookup or name lookup
+explicitly.
 
 Access by ID
 ~~~~~~~~~~~~

--- a/docs/source/guide/integration_design.rst
+++ b/docs/source/guide/integration_design.rst
@@ -3,8 +3,7 @@
 Integration Design Guide
 ========================
 
-This page ties together the behavior described elsewhere in the guide and turns
-it into practical rules of thumb for long-running integrations.
+Use these guidelines when designing long-running integrations.
 
 Integration Cost Model
 ----------------------
@@ -12,7 +11,7 @@ Integration Cost Model
 Cheap Operations
 ~~~~~~~~~~~~~~~~
 
-These are usually in-memory:
+These operations use already-loaded local state:
 
 - Reading fields on objects you already loaded.
 - Reusing materialized ``children`` and ``entries`` collections.
@@ -21,7 +20,7 @@ These are usually in-memory:
 Expensive Operations
 ~~~~~~~~~~~~~~~~~~~~
 
-These usually trigger remote work:
+These operations issue API calls or can cause many API calls:
 
 - First access to lazy collections such as ``children`` and ``entries``.
 - Calling ``refresh()`` and then reading the same objects again.
@@ -31,29 +30,21 @@ These usually trigger remote work:
 Design Guidelines
 -----------------
 
-- Prefer ID-first state in your integration model. Names and paths are best
-  treated as discovery and presentation data.
+- Store LabArchives IDs as the primary references in integration state. Names
+  and paths are best treated as discovery and presentation data.
 - Keep traversal bounded by scope and depth, and favor incremental scans over
   full rescans.
-- Place ``refresh()`` at synchronization boundaries where outside mutation is
-  plausible.
+- Place ``refresh()`` before reads that must include changes made by another
+  user, the web UI, or another API session.
 - After ``refresh()``, reacquire child objects from the refreshed parent before
-  trusting child fields.
-- After failures, re-resolve from a stable anchor such as a known parent plus
-  stored ID metadata.
+  reading child fields.
+- After failures, look up the parent by stored ID, then re-read the child by
+  ID.
 
 Suggested Reading Order
 -----------------------
 
-1. :ref:`index_access`
-2. :ref:`paths`
-3. :ref:`clearing_cache`
-4. :ref:`api_calls`
-
-Related Pages
--------------
-
-- :ref:`index_access` for duplicate-name and explicit lookup behavior.
-- :ref:`paths` for traversal and enumeration rules.
-- :ref:`clearing_cache` for cache invalidation and stale-reference behavior.
-- :ref:`api_calls` for low-level request access patterns.
+1. :ref:`index_access` for duplicate-name and explicit lookup behavior.
+2. :ref:`paths` for traversal and enumeration rules.
+3. :ref:`clearing_cache` for cache invalidation and stale-reference behavior.
+4. :ref:`api_calls` for low-level request access patterns.

--- a/docs/source/guide/json_entries.rst
+++ b/docs/source/guide/json_entries.rst
@@ -3,21 +3,18 @@
 JSON Entries
 ============
 
-``labapi`` provides a high-level way to store JSON data so it is both
-machine-readable and easy to inspect in the LabArchives UI.
+Use :meth:`~labapi.entry.collection.Entries.create_json_entry` to upload JSON
+and add a rich-text preview to the same page.
 
 How JSON Entries Are Stored
 ---------------------------
 
 When you create a JSON entry with ``labapi``, the library creates two related
-records:
+entries:
 
-- A JSON attachment that preserves the original structured data exactly.
+- A JSON attachment that stores the JSON-serialized data.
 - A rich-text preview entry that shows a formatted, human-readable version in
   the notebook page.
-
-This pairing makes it easy to keep a reliable machine format without giving up
-on readable notebook content.
 
 Create a JSON Entry
 -------------------
@@ -46,18 +43,9 @@ Use :meth:`~labapi.entry.collection.Entries.create_json_entry` on
    print(f"Created attachment entry (ID: {attachment_entry.id})")
    print(f"Created text preview (ID: {text_entry.id})")
 
-What You Get Back
------------------
-
-:meth:`~labapi.entry.collection.Entries.create_json_entry` returns both created
-entry objects:
-
-- ``attachment_entry`` for the uploaded ``.json`` attachment.
-- ``text_entry`` for the pretty-printed preview shown on the page.
-
 Related Pages
 -------------
 
-- :ref:`entries` for the surrounding entry model.
+- :ref:`entries` for entry types and entry creation methods.
 - :doc:`/examples/json_sync` for a complete JSON sync workflow.
-- :ref:`limitations` for current capability boundaries.
+- :ref:`limitations` for caveats that apply to JSON entries.

--- a/docs/source/guide/limitations.rst
+++ b/docs/source/guide/limitations.rst
@@ -3,13 +3,12 @@
 Capabilities and Limitations
 ============================
 
-This page summarizes the current scope of ``labapi`` in one place so you can plan around known boundaries.
-It applies to the current documentation set and reflects behavior verified at the time of writing.
+This page summarizes the current scope of ``labapi`` and its known limitations.
 
 Current Capabilities
 --------------------
 
-``labapi`` currently supports the following common workflows well:
+``labapi`` supports these workflows reliably:
 
 * Navigating notebooks, directories, and pages by path or index.
 * Creating and editing text entries (rich text, plain text, and headers).
@@ -20,19 +19,20 @@ Current Capabilities
 Known Limitations and Caveats
 -----------------------------
 
-Unsupported entry types are wrapped as ``UnknownEntry``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unsupported entry types are wrapped as fallback entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a page contains entry types that ``labapi`` does not model yet, those
-entries are wrapped as :class:`~labapi.entry.entries.unknown.UnknownEntry` and
-loaded with a warning. This preserves page order and IDs, but editing behavior
-is limited for those fallback objects.
+entries are loaded with a warning: unrecognized part types are wrapped as
+:class:`~labapi.entry.entries.unknown.UnknownEntry`, and
+recognized-but-unimplemented types as
+:class:`~labapi.entry.entries.unknown.UnimplementedEntry`. The objects keep
+their order and IDs, but assigning ``content`` raises ``NotImplementedError``.
 
 Widget entries are read-only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :class:`~labapi.entry.entries.widget.WidgetEntry` is supported for reading only.
-You can inspect widget content, but editing widget content is not currently supported.
 
 Duplicate names return first-match results by default
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -55,11 +55,10 @@ Re-fetch children from the refreshed parent object instead of reusing old refere
 ``copy_to()`` has copy fidelity limits and placement restrictions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The copy API has several practical caveats:
-
 * LabArchives may rename attachments during copy.
-* Widget and other specialized entry types are not fully supported for copy operations.
-* Copy attempts that include unsupported entry types can fail or produce incomplete copies.
+* Widget, unknown, and unimplemented entries may be skipped during page copy.
+* When an entry cannot be recreated, ``copy_to()`` emits a ``RuntimeWarning`` and skips that
+  entry; the copied page may be incomplete.
 * Copying a directory into itself or into one of its descendants raises :class:`ValueError`.
 
 ``enumerate_all()`` can return partial results on larger trees
@@ -80,18 +79,20 @@ Attachment update API can return a ``4999`` error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some attachment update operations can fail with a LabArchives ``4999`` error response.
-If this occurs, retrying with a fresh object/session and validating attachment metadata is recommended.
+On this error, reload the page or entry in a new session, verify the attachment filename,
+caption, and content type, then retry once.
 
 Planning Guidance
 -----------------
 
-To reduce surprises in production integrations:
+For production integrations:
 
 - Prefer ID-based addressing in automation.
-- Refresh parent nodes before critical reads and then re-fetch child objects.
+- Refresh parent nodes before reads that must include external changes and then
+  re-fetch child objects.
 - Validate copied content, especially attachments and specialized entries.
-- Treat unsupported entry types and ``4999`` attachment-update failures as
-  expected error-handling cases.
+- Add explicit handlers for unsupported entry types and ``ApiError`` code
+  ``4999`` during attachment updates.
 
 Related Pages
 -------------

--- a/docs/source/guide/paths.rst
+++ b/docs/source/guide/paths.rst
@@ -3,13 +3,11 @@
 Working with Paths
 ==================
 
-Paths provide a way to navigate, reference, and create nodes in the notebook tree using Unix-style
-slash-separated strings. This is an alternative to chained index access and is especially useful
-when working with deeply nested structures.
+Use slash-separated path strings to navigate, reference, and create notebook tree nodes; paths
+avoid long chains of indexing when structures are deeply nested.
 
-.. warning::
-   For duplicate-name and first-match lookup behavior, see
-   :ref:`index_access`. This page focuses on path syntax and traversal rules.
+.. seealso::
+   :ref:`index_access` for duplicate-name and first-match lookup behavior.
 
 .. code-block:: python
 
@@ -76,17 +74,17 @@ strings, including ``traverse()``, ``create()``, ``dir()``, and ``page()``.
 
 .. code-block:: python
 
-    # Literal name "Figure / 1"
+    # Literal name "Figure/1"
     figure = notebook.traverse(r"Experiments/Figure\/1")
 
-    # Literal name "Reports / 2024"
+    # Literal name "Reports/2024"
     page = notebook.page(r"Reports\/2024")
 
 Programmatic Escaping
 ^^^^^^^^^^^^^^^^^^^^^
 
 If you are building paths from variables that might contain slashes, use
-:meth:`~labapi.util.path.NotebookPath.escape` to safely prepare the segments:
+:meth:`~labapi.util.path.NotebookPath.escape` to escape the segments:
 
 .. code-block:: python
 
@@ -104,13 +102,12 @@ segment string:
 
 .. code-block:: python
 
-    print(NotebookPath.unescape(r"Results\/Final")) # "Results / Final"
+    print(NotebookPath.unescape(r"Results\/Final")) # "Results/Final"
 
 .. note::
-   To inspect duplicate child names under a container, use explicit indexing
-   on that container (for example, ``container[Index.Name: "Results"]``)
-   to retrieve all matches; then use ``Index.Id`` to select exactly one
-   (see :ref:`index_access`).
+   To list children with the same name, call
+   ``container[Index.Name: "Results"]``; then use ``Index.Id`` to select one
+   match (see :ref:`index_access`).
 
 .. warning::
    Nodes with the literal name ``".."`` cannot be accessed via ``traverse``,
@@ -119,13 +116,13 @@ segment string:
 Enumerating Descendants
 -----------------------
 
-The enumeration methods return relative path strings for all descendants, up to a specified depth.
-This is useful for listing or searching the tree without fetching every node individually.
+The enumeration methods return relative path strings for descendants through the requested depth,
+which lets you list or search tree paths without traversing each path separately.
 
 .. code-block:: python
 
-    # All descendants (directories and pages), depth 1 (default)
-    notebook.enumerate_all()
+    # All descendants (directories and pages) through depth 2
+    notebook.enumerate_all(depth=2)
     # e.g. ["Experiments", "Experiments/2024", "Protocols"]
 
     # Only directories
@@ -134,8 +131,8 @@ This is useful for listing or searching the tree without fetching every node ind
     # Only pages
     notebook.enumerate_pages(depth=2)
 
-``depth`` defaults to ``1`` (immediate children only). To fetch the full tree you can increase
-it, but be aware that this makes one API request per directory level visited.
+``depth`` defaults to ``1`` (immediate children only). Increase ``depth`` to include more
+levels; each directory visited adds one API request.
 
 .. code-block:: python
 
@@ -145,6 +142,11 @@ it, but be aware that this makes one API request per directory level visited.
     for path in all_paths:
         node = notebook.traverse(path)
         print(path, "->", node.id)
+
+.. note::
+   Use :meth:`~labapi.tree.mixins.AbstractTreeContainer.enumerate_nodes` to get
+   ``(path, node)`` pairs directly instead of re-traversing, since first-match
+   name lookup can pick the wrong node when sibling names repeat.
 
 Creating Nodes with Paths
 -------------------------
@@ -161,8 +163,9 @@ automatically.
     # Create a page at a nested path; intermediate directories are created as needed
     page = notebook.create(NotebookPage, "Experiments/2024/Results", parents=True)
 
-    # Without parents=True, a ValueError is raised if an intermediate directory is missing
-    page = notebook.create(NotebookPage, "Experiments/2024/Results")  # raises if missing
+    # Without parents=True, create() raises ValueError for any multi-segment path,
+    # even when the intermediate directories already exist
+    page = notebook.create(NotebookPage, "Experiments/2024/Results")  # raises ValueError
 
 See :ref:`creating_pages` for details on the ``if_exists`` parameter and other creation options.
 
@@ -203,8 +206,8 @@ with:
 When to Use Them
 ~~~~~~~~~~~~~~~~
 
-Use ``dir()`` and ``page()`` when you want concise, idempotent setup code.
-They are especially useful in scripts that may run repeatedly.
+Use ``dir()`` and ``page()`` when missing directories or pages should be
+created and existing matches should be returned.
 
 .. code-block:: python
 
@@ -212,12 +215,8 @@ They are especially useful in scripts that may run repeatedly.
     notebook.dir("Experiments/2024").page("Results")
     notebook.page("Experiments/2024/Raw Data")
 
-Because both methods retain existing nodes, calling them again for the same
-path returns the existing directory/page instead of creating a duplicate.
-
-They can also be used for navigation when you expect the path to already
-exist: the same call either returns the existing node or creates it if
-missing.
+For read-only navigation, use ``traverse()``. Use ``dir()`` or ``page()``
+only when creating a missing node is acceptable.
 
 .. code-block:: python
 
@@ -230,9 +229,8 @@ missing.
 The NotebookPath Class
 ----------------------
 
-:class:`~labapi.util.path.NotebookPath` is a structured path object that can be constructed from
-nodes or strings, combined with ``/``, and converted back to strings. It is used internally by
-``traverse`` and ``create``, but is also available for your own path logic.
+:class:`~labapi.util.path.NotebookPath` represents parsed notebook paths. Use it to compose,
+resolve, compare, or stringify paths before calling ``traverse()`` or ``create()``.
 
 **Constructing a path from a node:**
 
@@ -243,7 +241,7 @@ nodes or strings, combined with ``/``, and converted back to strings. It is used
     path = NotebookPath(folder)
     print(path)           # /Experiments/2024
     print(path.name)      # 2024  (last segment)
-    print(path.parts)     # ['Experiments']  (all but last)
+    print(path.parts)     # ('Experiments',)  (all but last)
     print(path.is_absolute())  # True
 
 **Constructing from a string:**

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,9 +5,6 @@ LabArchives API Client
 object-oriented way to authenticate, browse notebook trees, and create or
 update entries from scripts, tools, and integrations.
 
-Choose the section that matches where you are in the workflow, then drop into
-the deeper guides when you need behavior details or API signatures.
-
 .. toctree::
    :maxdepth: 2
    :hidden:
@@ -28,33 +25,33 @@ Start Here
       :link: quick_start/index
       :link-type: doc
 
-      Install ``labapi``, authenticate locally, and make your first successful
-      write call.
+      Install ``labapi``, authenticate locally, and create your first
+      LabArchives entry.
 
    .. grid-item-card:: User Guide
       :link: guide/index
       :link-type: doc
 
-      Learn the behavior behind traversal, entry handling, authentication, and
-      caching.
+      Read how traversal, entries, authentication, and caching work.
 
    .. grid-item-card:: Example Applications
       :link: examples/index
       :link-type: doc
 
-      Run end-to-end scripts for JSON sync, folder export, and CSV table
-      workflows.
+      Run scripts that sync JSON, export folders, and update CSV-backed
+      tables.
 
    .. grid-item-card:: API Reference
       :link: reference/index
       :link-type: doc
 
-      Look up classes, methods, and generated module documentation.
+      Look up class, method, and module reference pages.
 
 Reference Tools
 ---------------
 
-- :ref:`faq` for operational troubleshooting and environment setup questions.
+- :ref:`faq` for authentication, certificate, and environment setup
+  troubleshooting.
 - :ref:`genindex` for the generated symbol index.
 - :ref:`modindex` for the module index.
-- :ref:`search` to search the built documentation directly.
+- :ref:`search` for full-text search.

--- a/docs/source/quick_start/copying.rst
+++ b/docs/source/quick_start/copying.rst
@@ -17,7 +17,7 @@ Copy a Page
    copied_page = source_page.copy_to(destination)
 
 This creates a new page in the destination directory with the same name and
-entries.
+its supported entries.
 
 Copy Across Notebooks
 ---------------------
@@ -51,24 +51,25 @@ Return Value
    print(f"Original: {source_page.id}")
    print(f"Copy: {new_page.id}")
 
-Important Limitations
----------------------
+Limitations
+-----------
 
 .. warning::
    LabArchives can rename attachment files during copy operations. The file
    data is preserved, but the copied filename may differ from the original.
 
 .. warning::
-   Widget entries and other specialized entry types are not fully supported for
-   copying. Unsupported content can cause errors or incomplete copies.
+   Only text, plain-text, header, and attachment entries are fully supported.
+   Other entry types, including widgets, may be skipped after a
+   ``RuntimeWarning``.
 
 Best Practices
 --------------
 
-- Test the copy flow on non-critical content first.
-- Verify the copied entry count and spot-check important attachments.
+- Test copying with a disposable page or directory first.
+- Verify the copied entry count, then open representative copied attachments
+  and compare filenames and content.
 - If filenames matter, re-read copied attachments and confirm their names.
-- Prefer descriptive destination names so copied content is easy to identify.
 
 Example verification:
 
@@ -87,7 +88,8 @@ Move Instead of Copying
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to relocate content instead of duplicating it, use
-:meth:`~labapi.tree.mixins.AbstractTreeNode.move_to`:
+:meth:`~labapi.tree.mixins.AbstractTreeNode.move_to` (moves are only possible
+within the same notebook):
 
 .. code-block:: python
 
@@ -96,8 +98,8 @@ If you want to relocate content instead of duplicating it, use
 Recreate Content Programmatically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For simple pages, it can be more reliable to create a new page and rebuild the
-content yourself:
+When copy fidelity matters, create a new page and recreate only the entry
+types you need:
 
 .. code-block:: python
 
@@ -112,6 +114,6 @@ content yourself:
 Related Pages
 -------------
 
-- :ref:`limitations` for the centralized copy and fidelity caveats.
-- :ref:`delete` for move-to-trash behavior.
+- :ref:`limitations` for known copy limitations.
+- :ref:`delete` for moving pages and directories to ``API Deleted Items``.
 - :ref:`navigating` for finding source and destination locations.

--- a/docs/source/quick_start/creating_pages.rst
+++ b/docs/source/quick_start/creating_pages.rst
@@ -3,9 +3,9 @@
 Creating Pages and Entries
 ==========================
 
-This page covers the basic write operations you will use most often: creating
-directories and pages, then adding entries to a page. The examples assume you
-already have a ``notebook`` object from :ref:`first_calls`.
+This page covers how to create directories and pages, then add entries to a
+page. The examples assume you already have a ``notebook`` object from
+:ref:`first_calls`.
 
 Notebook Structure
 ------------------
@@ -32,8 +32,7 @@ Use :meth:`~labapi.tree.mixins.AbstractTreeContainer.create` to add new
    subfolder = my_folder.create(NotebookDirectory, "2024 Results")
 
 .. note::
-   Tree mutation methods update local cached objects immediately. The created
-   node is ready to use right away.
+   Tree mutation methods update local cached objects immediately.
 
 Handle Existing Nodes
 ~~~~~~~~~~~~~~~~~~~~~
@@ -54,7 +53,7 @@ type already exists. Use ``if_exists`` to choose a different behavior:
 Create Entries
 --------------
 
-Use :meth:`~labapi.entry.collection.Entries.create` to add content blocks to a
+Use :meth:`~labapi.entry.collection.Entries.create` to add entries to a
 page:
 
 .. code-block:: python
@@ -105,6 +104,6 @@ Access entries through the page's ``entries`` collection:
 Related Pages
 -------------
 
-- :ref:`navigating` for getting to the right page first.
-- :ref:`entries` for deeper entry-class behavior and editing semantics.
+- :ref:`navigating` for locating a target page before adding entries.
+- :ref:`entries` for how each entry class stores, updates, and returns content.
 - :ref:`uploading_files` for attachment-specific details.

--- a/docs/source/quick_start/deleting.rst
+++ b/docs/source/quick_start/deleting.rst
@@ -4,8 +4,9 @@ Deleting Pages and Directories
 ==============================
 
 Use :meth:`~labapi.tree.mixins.AbstractTreeNode.delete` to move pages and
-directories into the notebook's ``API Deleted Items`` folder. This is a safe
-delete workflow rather than a permanent erase.
+directories into the notebook's ``API Deleted Items`` folder. ``delete()``
+renames the item and moves it to ``API Deleted Items``; it does not
+permanently erase the item.
 
 How Deletion Works
 ------------------
@@ -14,8 +15,6 @@ When you delete a page or directory:
 
 1. The item is renamed with a deletion timestamp.
 2. The item is moved to ``API Deleted Items`` under the notebook root.
-
-This preserves the content so you can recover it later.
 
 Delete a Page
 -------------
@@ -39,10 +38,8 @@ Delete a Directory
    directory = notebook.traverse("Old Project")
    directory.delete()
 
-.. warning::
-   Deleting a directory moves all of its pages and subdirectories together.
-   Confirm that you want to relocate the entire subtree before you call
-   ``delete()``.
+Deleting a directory moves the directory itself — including all of its pages
+and subdirectories — into ``API Deleted Items``.
 
 Recover Deleted Items
 ---------------------
@@ -65,11 +62,13 @@ Entry Deletion
 
 .. note::
    Individual entries such as text entries, attachments, and headers cannot be
-   deleted through the API at this time.
+   deleted through the API.
 
 Related Pages
 -------------
 
-- :ref:`entries` for current entry-type capabilities.
-- :ref:`limitations` for the broader capability summary.
-- :ref:`copying` if you want duplication rather than move-to-trash behavior.
+- :ref:`entries` for which entry types can be read or updated.
+- :ref:`limitations` for known API operations that ``labapi`` does not
+  implement.
+- :ref:`copying` if you want duplication rather than moving content to
+  ``API Deleted Items``.

--- a/docs/source/quick_start/first_calls.rst
+++ b/docs/source/quick_start/first_calls.rst
@@ -7,6 +7,32 @@ This page shows the credential and authentication patterns used throughout the
 docs. It assumes you already installed a suitable profile from
 :ref:`installation`.
 
+.. _obtaining_api_keys:
+
+Obtain API Keys
+---------------
+
+Every request to the LabArchives API is signed with an Access Key ID
+(``akid``) and Access Password issued by LabArchives. These identify your
+application; the sign-in flows further down this page additionally
+authenticate individual users. There is no self-service portal for API keys —
+they are issued on request:
+
+- If your institution has a LabArchives enterprise license, ask your
+  institution's LabArchives site administrator (or your LabArchives Enterprise
+  Success Team contact) to request API access. Provide the name and email
+  address for each existing LabArchives account that needs API access.
+- Otherwise, contact LabArchives support at
+  `support@labarchives.com <mailto:support@labarchives.com>`_.
+
+When issuing the keys, LabArchives will confirm the API base URL for
+your region (for example, ``https://api.labarchives.com`` for US-hosted
+accounts — the default used throughout these docs).
+
+Treat the Access Password like any other secret: keep it out of version
+control and supply it via a ``.env`` file or environment variables as shown
+below.
+
 Create a Client
 ---------------
 
@@ -95,13 +121,10 @@ API URL, Access Key ID, and Access Password in several ways:
 Sign In
 -------
 
-To interact with the LabArchives API, you need to authenticate. The sections
-below cover the main workflows.
-
 Local Interactive Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The simplest path is
+For local interactive use, call
 :meth:`~labapi.client.Client.default_authenticate`, which lets users running on
 the same machine sign in through a browser.
 
@@ -113,8 +136,8 @@ the same machine sign in through a browser.
        user = client.default_authenticate()
 
 .. note::
-   The local interactive path works best with
-   ``labapi[dotenv,builtin-auth]``. If automatic browser launch is
+   Use ``labapi[dotenv,builtin-auth]`` for ``.env`` loading and automatic
+   browser launch. If automatic browser launch is
    unavailable, ``labapi`` falls back to printing a URL so you can finish the
    login manually.
 
@@ -126,8 +149,8 @@ the same machine sign in through a browser.
 External App Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you cannot use a browser on the same machine, or you want a quick manual
-test path, use an External App authentication code:
+If you cannot use a browser on the same machine, or for a manual login test,
+use an External App authentication code:
 
 1. Log in to your LabArchives account in a web browser.
 2. Click your name in the top-right corner and select
@@ -160,8 +183,7 @@ Recommended flow:
 4. Store any resulting credentials or secrets using your platform's secret
    manager.
 
-For implementation details and operational guidance, see the full
-:ref:`Authentication guide <auth>`.
+For the complete flow, see :ref:`auth`.
 
 Get a Notebook
 --------------
@@ -182,16 +204,14 @@ name or iterate over them:
 Write Entries
 -------------
 
-After you have a notebook, navigate to a page and create entries:
+After you have a notebook, navigate to a page and create entries. Choose the
+entry class by the output you want in LabArchives:
 
-.. tip::
-   Choose the entry type based on what LabArchives should render:
-
-   - :class:`~labapi.entry.entries.text.TextEntry` renders HTML formatting.
-   - :class:`~labapi.entry.entries.text.PlainTextEntry` preserves text
-     literally.
-   - :class:`~labapi.entry.entries.text.HeaderEntry` creates a visible section
-     divider.
+- :class:`~labapi.entry.entries.text.TextEntry` renders HTML formatting.
+- :class:`~labapi.entry.entries.text.PlainTextEntry` preserves text
+  literally.
+- :class:`~labapi.entry.entries.text.HeaderEntry` creates a visible section
+  divider.
 
 .. code-block:: python
 
@@ -208,4 +228,4 @@ Related Pages
 
 - :ref:`auth` for full interactive and server-side authentication flows.
 - :ref:`navigating` for path-based notebook traversal after login.
-- :ref:`entries` for deeper coverage of entry classes and content handling.
+- :ref:`entries` for how entry classes store and update content.

--- a/docs/source/quick_start/index.rst
+++ b/docs/source/quick_start/index.rst
@@ -3,9 +3,8 @@
 Quick Start
 ===========
 
-Use the quick start when you want the shortest path from installation to a
-successful notebook change. These pages move from setup to common write
-operations.
+Start with installation and authentication, then create, navigate, upload,
+copy, and delete notebook content.
 
 .. toctree::
    :maxdepth: 1
@@ -23,15 +22,15 @@ operations.
 Recommended Reading Order
 -------------------------
 
-1. :doc:`tutorial` for the fastest copy/paste path.
+1. :doc:`tutorial` for the runnable first script.
 2. :doc:`installation` for package-manager commands and optional extras.
 3. :doc:`first_calls` for credential setup and authentication patterns.
-4. :doc:`navigating` and :doc:`creating_pages` for the basic tree and write
-   operations.
+4. :doc:`navigating` and :doc:`creating_pages` for creating directories,
+   pages, and entries, then navigating the notebook tree.
 
 Related Pages
 -------------
 
-- :ref:`guide` for deeper behavior details and caveats.
+- :ref:`guide` for behavior notes outside the quick start.
 - :ref:`examples` for runnable end-to-end scripts.
 - :ref:`faq` for browser and certificate troubleshooting.

--- a/docs/source/quick_start/installation.rst
+++ b/docs/source/quick_start/installation.rst
@@ -3,8 +3,8 @@
 Installation
 ============
 
-This page shows the supported install profiles for ``labapi`` and the matching
-credential setup options used throughout the rest of the docs.
+Install ``labapi`` with the extras you need, then configure credentials with
+``.env`` or environment variables.
 
 Python Version
 --------------
@@ -14,7 +14,7 @@ Supports Python 3.10 and newer.
 Choose an Install Profile
 -------------------------
 
-Pick the smallest install profile that matches how you plan to use ``labapi``:
+Choose the install target that includes the helpers you need:
 
 .. list-table::
    :header-rows: 1
@@ -24,8 +24,8 @@ Pick the smallest install profile that matches how you plan to use ``labapi``:
      - Use When
    * - Recommended local interactive
      - ``labapi[dotenv,builtin-auth]``
-     - You want the quick start, examples, ``.env`` loading, and browser-based
-       ``default_authenticate()``.
+     - You want ``.env`` loading and browser-based ``default_authenticate()``
+       for local examples.
    * - Minimal
      - ``labapi``
      - You already manage environment variables or pass credentials directly,
@@ -66,7 +66,7 @@ Pick the smallest install profile that matches how you plan to use ``labapi``:
 Optional Extras
 ---------------
 
-``labapi`` currently exposes two optional extras:
+``labapi`` has two optional extras:
 
 - ``dotenv`` lets :class:`~labapi.client.Client` read ``API_URL``,
   ``ACCESS_KEYID``, and ``ACCESS_PWD`` from a local ``.env`` file.
@@ -118,6 +118,6 @@ before running your code:
 Related Pages
 -------------
 
-- :ref:`first_success_tutorial` for the fastest first-run workflow.
+- :ref:`first_success_tutorial` for the runnable first script.
 - :ref:`first_calls` for authentication and notebook access patterns.
 - :ref:`faq` for browser and certificate troubleshooting.

--- a/docs/source/quick_start/navigating.rst
+++ b/docs/source/quick_start/navigating.rst
@@ -15,8 +15,7 @@ you already have a ``notebook`` object from :ref:`first_calls`.
 Traversing the Tree with Paths
 ------------------------------
 
-The most common way to navigate is with
-:meth:`~labapi.tree.mixins.AbstractBaseTreeNode.traverse`, which accepts a
+Use :meth:`~labapi.tree.mixins.AbstractBaseTreeNode.traverse`, which accepts a
 slash-separated path string.
 
 .. code-block:: python
@@ -29,7 +28,7 @@ slash-separated path string.
 Fluent Navigation with ``dir()`` and ``page()``
 -----------------------------------------------
 
-For a more concise style, use
+To create or retrieve nodes while chaining calls, use
 :meth:`~labapi.tree.mixins.AbstractTreeContainer.dir` and
 :meth:`~labapi.tree.mixins.AbstractTreeContainer.page`.
 
@@ -41,8 +40,8 @@ missing.
    page = notebook.dir("Experiments").dir("Project A").page("Results")
    page = notebook.dir("Experiments/Project A").page("Results")
 
-See :meth:`~labapi.tree.mixins.AbstractTreeContainer.create` for more control
-over duplicate handling and parent creation.
+See :meth:`~labapi.tree.mixins.AbstractTreeContainer.create` to set
+duplicate-handling and parent-creation behavior.
 
 Accessing Children by Name
 --------------------------
@@ -61,7 +60,8 @@ Use dictionary-style indexing to get the first child with a matching name:
 Accessing Children by ID or Name
 --------------------------------
 
-For more explicit lookups, use :class:`~labapi.util.types.Index`.
+Use :class:`~labapi.util.types.Index` when you need to choose ID or name
+lookup explicitly.
 
 Access by ID
 ~~~~~~~~~~~~
@@ -99,24 +99,21 @@ List All Children
    experiments = notebook["Experiments"]
    experiment_items = experiments.enumerate_all(depth=2)
 
-.. note::
-   The ``depth`` parameter controls how many levels deep ``labapi`` walks the
-   tree.
+``depth`` limits how many levels of the tree are walked. Given this tree
+structure::
 
-   Given this tree structure::
+   Notebook/
+   |-- Experiments/
+   |   |-- 2024/
+   |   |   `-- Results
+   |   `-- Archive
+   `-- Notes
 
-      Notebook/
-      |-- Experiments/
-      |   |-- 2024/
-      |   |   `-- Results
-      |   `-- Archive
-      `-- Notes
-
-   - ``depth=1`` returns ``["Experiments", "Notes"]``.
-   - ``depth=2`` returns
-     ``["Experiments", "Experiments/2024", "Experiments/Archive", "Notes"]``.
-   - ``depth=3`` returns
-     ``["Experiments", "Experiments/2024", "Experiments/2024/Results", "Experiments/Archive", "Notes"]``.
+- ``depth=1`` returns ``["Experiments", "Notes"]``.
+- ``depth=2`` returns
+  ``["Experiments", "Experiments/2024", "Experiments/Archive", "Notes"]``.
+- ``depth=3`` returns
+  ``["Experiments", "Experiments/2024", "Experiments/2024/Results", "Experiments/Archive", "Notes"]``.
 
 List Only Directories
 ~~~~~~~~~~~~~~~~~~~~~
@@ -176,5 +173,5 @@ Related Pages
 -------------
 
 - :ref:`first_calls` for getting the initial ``notebook`` object.
-- :ref:`paths` for deeper path-resolution rules.
+- :ref:`paths` for how paths are parsed and resolved.
 - :ref:`index_access` for duplicate-name and explicit lookup behavior.

--- a/docs/source/quick_start/tutorial.rst
+++ b/docs/source/quick_start/tutorial.rst
@@ -3,8 +3,7 @@
 First Success Tutorial
 ======================
 
-This page is the shortest copy/paste path for first-time users. Follow the
-steps below and you should end up with one visible text entry in LabArchives.
+These steps create one visible text entry in LabArchives.
 
 Install ``labapi``
 ------------------
@@ -43,8 +42,8 @@ Replace the values with your own LabArchives API credentials.
 Run a Minimal Script
 --------------------
 
-Copy this script into ``first_success.py``. It automatically uses the first
-notebook in your account.
+Copy this script into ``first_success.py``. It uses the first notebook in
+your account.
 
 .. code-block:: python
 
@@ -75,17 +74,14 @@ Confirm the Result
 
 After the script finishes:
 
-- You should see a new page in your selected notebook named
+- The selected notebook contains a new page named
   ``API tutorial - <timestamp>``.
-- Opening that page should show one text entry with the message
+- Opening that page shows one text entry with the message
   ``Hello from labapi!``.
-
-If this worked, you have completed a full installation, authentication, and
-write path.
 
 Related Pages
 -------------
 
-- :ref:`installation` for the broader install matrix.
+- :ref:`installation` for all install profiles.
 - :ref:`first_calls` for more detail on credentials and authentication options.
-- :ref:`creating_pages` for follow-up tree and entry operations.
+- :ref:`creating_pages` for creating directories, pages, and entries.

--- a/docs/source/quick_start/uploading_files.rst
+++ b/docs/source/quick_start/uploading_files.rst
@@ -3,14 +3,15 @@
 Uploading Files
 ===============
 
-Uploading attachments is a two-step workflow: create an
-:class:`~labapi.entry.attachment.Attachment`, then create an attachment entry on
-the target page. The examples below assume you already have a ``page`` object.
+To upload an attachment, create an
+:class:`~labapi.entry.attachment.Attachment` and then create an attachment
+entry on the target page. The examples below assume you already have a
+``page`` object.
 
 Create an Attachment
 --------------------
 
-Build an :class:`~labapi.entry.attachment.Attachment` from a filename or path:
+Build an :class:`~labapi.entry.attachment.Attachment` from a file path:
 
 .. code-block:: python
 
@@ -20,7 +21,8 @@ Build an :class:`~labapi.entry.attachment.Attachment` from a filename or path:
 
 .. note::
    :meth:`~labapi.entry.attachment.Attachment.from_file` accepts a filesystem
-   path or a random-access binary file object. When a path is provided,
+   path or a named, random-access binary file object (it must have a ``name``
+   attribute). When a path is provided,
    ``labapi`` opens the file in binary mode automatically. File objects must
    support random access so the library can rewind the stream before copying.
 
@@ -35,7 +37,7 @@ upload size:
 
 .. code-block:: python
 
-   max_size_bytes = user.get_max_upload_size()
+   max_size_bytes = page.user.get_max_upload_size()
    print(f"Max upload size: {max_size_bytes / 1024 / 1024:.1f} MB")
 
 Upload the Attachment
@@ -82,6 +84,7 @@ If you want a specific caption, construct the
 Related Pages
 -------------
 
-- :ref:`creating_pages` for the broader page-and-entry creation workflow.
+- :ref:`creating_pages` for creating pages before adding entries.
 - :ref:`entries` for attachment entry behavior and update semantics.
-- :ref:`limitations` for current capability boundaries.
+- :ref:`limitations` for unsupported LabArchives features and known
+  limitations.

--- a/docs/source/quick_start/writing_rich_text.rst
+++ b/docs/source/quick_start/writing_rich_text.rst
@@ -111,4 +111,4 @@ Related Pages
 
 - :ref:`entries` for entry type behavior and update semantics.
 - :doc:`/examples/csv_table` for a complete CSV-to-HTML workflow.
-- :ref:`creating_pages` for the surrounding page-and-entry creation pattern.
+- :ref:`creating_pages` for creating a page before adding rich-text entries.

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -1,7 +1,7 @@
 """LabArchives API Client.
 
 This module provides the core client for interacting with the LabArchives API,
-handling authentication, request signing, and various API call methods.
+handling authentication, request signing, and API calls.
 """
 
 from __future__ import annotations
@@ -104,9 +104,9 @@ class StreamingResponse:
 class _313HTTPAdapter(HTTPAdapter):
     """Custom HTTP adapter that disables strict X.509 certificate verification.
 
-    This adapter is used to work around certain SSL certificate validation issues
-    by disabling the VERIFY_X509_STRICT flag. This allows the client to connect
-    to servers with certificates that might not pass strict validation.
+    This adapter disables the VERIFY_X509_STRICT flag. This allows the client
+    to connect to servers with certificates that might not pass strict
+    validation.
 
     .. warning::
        This reduces security by relaxing certificate validation. Use only when
@@ -115,9 +115,6 @@ class _313HTTPAdapter(HTTPAdapter):
 
     def init_poolmanager(self, *args: Any, **kwargs: Any):
         """Initialize the connection pool manager with a custom SSL context.
-
-        This method overrides the default pool manager initialization to inject
-        a custom SSL context that disables strict X.509 verification.
 
         :param args: Positional arguments to pass to the parent init_poolmanager.
         :param kwargs: Keyword arguments to pass to the parent init_poolmanager.
@@ -318,9 +315,8 @@ class Client:
     def close(self) -> None:
         """Close the underlying requests session.
 
-        Once closed, this client should not be used for further API requests.
-        Any :class:`~labapi.user.User` objects derived from this client should
-        also be treated as no longer usable for API calls.
+        Once closed, API calls through this client — including via derived
+        :class:`~labapi.user.User` objects — raise :class:`RuntimeError`.
         """
         if not self._closed:
             self.session.close()
@@ -776,8 +772,8 @@ class Client:
     def _signature(self, api_method: str, expiry: int) -> str:
         """Generate the HMAC-SHA512 signature for a LabArchives API request.
 
-        This private method is used internally by `_sign_url` to create the
-        cryptographic signature based on the Access Key ID, API method, and expiry.
+        Called by `_sign_url`; the signature covers the Access Key ID, API
+        method, and expiry.
 
         :param api_method: The specific API method name used in the signature calculation.
         :param expiry: The expiration timestamp (in milliseconds since epoch) for the request.
@@ -799,8 +795,8 @@ class Client:
     ) -> str:
         """Sign a URL and append the LabArchives auth query parameters.
 
-        This private method appends the Access Key ID, expiration timestamp, and
-        the generated signature to the URL's query string.
+        Appends the Access Key ID, expiration timestamp, and signature to the
+        URL's query string.
 
         :param url: The unsigned URL to be signed.
         :param api_method: The specific API method name used for signature generation.

--- a/src/labapi/entry/attachment.py
+++ b/src/labapi/entry/attachment.py
@@ -62,8 +62,7 @@ class Attachment:
     """Represents an attachment file with associated metadata.
 
     This class wraps a file-like object (such as BytesIO or TemporaryFile) along
-    with metadata like MIME type, filename, and caption. It provides a convenient
-    interface for working with file attachments in LabArchives.
+    with metadata like MIME type, filename, and caption.
 
     .. note::
        Write operations to the backing buffer need explicit syncing with the server.
@@ -102,8 +101,8 @@ class Attachment:
         cloning it. The MIME type is automatically guessed from the local file
         name. If the MIME type cannot be determined, it defaults to
         ``"application/octet-stream"``. File-like inputs must support random
-        access so ``labapi`` can rewind them, typically via ``seekable()`` or
-        working ``seek()`` and ``tell()`` methods.
+        access so ``labapi`` can rewind them, checked via ``seekable()`` when
+        present, otherwise via working ``seek()`` and ``tell()`` methods.
 
         :param file: The filesystem path or file object to create an
                      attachment from.

--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -94,9 +94,8 @@ class Entries(Sequence["Entry[Any]"]):
     ) -> tuple[AttachmentEntry, TextEntry]:
         """Create a JSON attachment plus a companion reference text entry.
 
-        This method uploads JSON data as an attachment file and creates a
-        companion text entry that references the attachment and displays
-        a formatted preview of the JSON data.
+        The companion text entry references the attachment's ID and displays a
+        formatted preview of the JSON data.
 
         :param data: The JSON-serializable data to upload.
         :param filename: Optional stable filename for the uploaded JSON attachment.

--- a/src/labapi/entry/comment.py
+++ b/src/labapi/entry/comment.py
@@ -10,6 +10,5 @@ from __future__ import annotations
 class Comment:
     """Represents a comment associated with an entity in LabArchives.
 
-    Currently, this class is a placeholder and does not contain specific
-    attributes or methods for comment management.
+    Currently a placeholder; comment operations are not yet implemented.
     """

--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -1,8 +1,4 @@
-"""Attachment Entry Module.
-
-This module defines the :class:`~labapi.entry.entries.attachment.AttachmentEntry` class,
-which represents an attachment entry within a LabArchives page.
-"""
+"""Attachment Entry Module."""
 
 from __future__ import annotations
 
@@ -73,8 +69,8 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
     def get_attachment(self, use_tempfile: bool = False) -> Attachment:
         """Return the attachment payload as an independent stream copy.
 
-        The attachment data is fetched from the LabArchives API and cached.
-        Subsequent calls will return the cached data.
+        The attachment data is fetched from the LabArchives API on first call
+        and cached.
 
         :param use_tempfile: If True, the attachment data will be stored in a
                              temporary file; otherwise, in an in-memory BytesIO object.

--- a/src/labapi/entry/entries/text.py
+++ b/src/labapi/entry/entries/text.py
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
 class PlainTextEntry(Entry[str], part_type="plain text entry"):
     """Represents a plain text entry on a LabArchives page.
 
-    This class is used for entries containing unformatted, raw text.
-    Additionally, it provides common functionalities for entries whose content is
-    represented as a string, including methods for getting and setting the content.
+    This class is used for entries containing unformatted text.
+    It also serves as the base class for string-content entries, providing the
+    ``content`` getter and setter.
     """
 
     def __init__(self, eid: str, data: str, user: User):

--- a/src/labapi/tree/collection.py
+++ b/src/labapi/tree/collection.py
@@ -2,7 +2,6 @@
 
 This module defines the :class:`~labapi.tree.collection.Notebooks` class,
 which acts as a collection manager for a user's LabArchives notebooks.
-It provides methods for accessing, iterating over, and creating notebooks.
 """
 
 from __future__ import annotations
@@ -25,8 +24,7 @@ class Notebooks(Mapping[IdOrNameIndex, Notebook | Sequence[Notebook]]):
     """A collection of LabArchives notebooks accessible to a user.
 
     This class provides dictionary-like access to notebooks by their ID or name,
-    and supports creating new notebooks. It manages a list of :class:`~labapi.tree.notebook.Notebook`
-    objects.
+    and supports creating new notebooks.
     """
 
     def __init__(self, notebooks: Sequence[NotebookInit], user: User):
@@ -56,7 +54,8 @@ class Notebooks(Mapping[IdOrNameIndex, Notebook | Sequence[Notebook]]):
     def __getitem__(self, key: IdOrNameIndex) -> Notebook | list[Notebook]:
         """Look up notebooks by name or indexed selector.
 
-        - If `key` is a string, it attempts to find a single notebook with that name.
+        - If `key` is a string, returns the first notebook with that name
+          (raises :exc:`KeyError` if none match).
         - If `key` is a slice with start of :attr:`~labapi.util.Index.Id`
           (e.g., ``Index.Id:"some_id"``),
           it returns the notebook with the matching ID.

--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -1,8 +1,7 @@
 """Tree Mixins Module.
 
 This module defines abstract base classes and mixins that form the hierarchical
-structure of LabArchives notebooks, directories, and pages. These classes
-provide common functionalities and properties for tree nodes and containers.
+structure of LabArchives notebooks, directories, and pages.
 """
 
 from __future__ import annotations
@@ -76,7 +75,7 @@ class HasNameMixin:
 class AbstractBaseTreeNode(ABC, HasNameMixin):
     """Abstract base class for any node within the LabArchives tree structure.
 
-    This class provides fundamental properties and methods common to all
+    This class provides properties and methods common to all
     tree nodes, such as ID, name, references to parent and root, and the
     associated user.
 
@@ -141,7 +140,8 @@ class AbstractBaseTreeNode(ABC, HasNameMixin):
     def tree_id(self) -> str:
         """Return the node identifier within the LabArchives tree.
 
-        This is often the same as `id` but can be used to distinguish if needed.
+        Equal to `id` for all nodes except the Notebook root, whose `tree_id`
+        is the sentinel "0" while `id` is the notebook ID.
 
         :returns: The tree ID of the node.
         """
@@ -259,9 +259,8 @@ class AbstractBaseTreeNode(ABC, HasNameMixin):
     def as_dir(self) -> AbstractTreeContainer:
         """Return this node cast to :class:`~labapi.tree.mixins.AbstractTreeContainer`.
 
-        This method provides a convenient way to perform directory-specific
-        operations on a node after checking its type, with static type
-        checking support.
+        Use after checking :meth:`is_dir` to obtain a container-typed
+        reference for static type checking.
 
         :returns: The node cast to an
                   :class:`~labapi.tree.mixins.AbstractTreeContainer`.
@@ -275,9 +274,8 @@ class AbstractBaseTreeNode(ABC, HasNameMixin):
     def as_page(self) -> NotebookPage:
         """Return this node cast to :class:`~labapi.tree.page.NotebookPage`.
 
-        This method provides a convenient way to perform page-specific
-        operations on a node after checking its type, with static type
-        checking support.
+        Use after checking :meth:`is_dir` to obtain a page-typed reference
+        for static type checking.
 
         :returns: The node cast to a
                   :class:`~labapi.tree.page.NotebookPage`.
@@ -539,7 +537,8 @@ class AbstractTreeContainer(
     ) -> AbstractBaseTreeNode | Sequence[AbstractBaseTreeNode]:
         """Look up child nodes by name or indexed selector.
 
-        - If `key` is a string, it attempts to find a single child with that name.
+        - If `key` is a string, returns the first child with that name
+          (raises :exc:`KeyError` if none match).
         - If `key` is a slice with start of :attr:`~labapi.util.Index.Id`
           (e.g., ``Index.Id:"some_id"``),
           it returns the child with the matching ID.
@@ -731,8 +730,6 @@ class AbstractTreeContainer(
         if_exists: InsertBehavior = InsertBehavior.Raise,
     ) -> T:
         """Create a child page or directory in this container.
-
-        This method supports different behaviors if a node with the same name already exists.
 
         :param cls: The class of the node to create (e.g., :class:`~labapi.tree.page.NotebookPage` or :class:`~labapi.tree.directory.NotebookDirectory`).
         :param name: The name of the new node.

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -3,7 +3,7 @@
 This module defines the :class:`~labapi.tree.notebook.Notebook` class,
 representing a LabArchives notebook. It extends :class:`~labapi.tree.mixins.AbstractTreeContainer`
 to manage its hierarchical content (directories and pages) and provides
-notebook-specific functionalities.
+notebook-level operations (renaming, default-notebook status, entry search).
 """
 
 from __future__ import annotations
@@ -26,8 +26,7 @@ class Notebook(AbstractTreeContainer):
     """Represents a LabArchives notebook, acting as the root of a tree structure.
 
     A notebook is a specialized :class:`~labapi.tree.mixins.AbstractTreeContainer`
-    that holds directories and pages. It provides methods to access notebook-specific
-    information and manage its contents.
+    that holds directories and pages.
     """
 
     def __init__(self, init: NotebookInit, user: User, notebooks: Notebooks):

--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -33,9 +33,8 @@ class NotebookPage(AbstractTreeNode):
     """Represents a single page within a LabArchives notebook.
 
     A `NotebookPage` is a leaf node in the tree structure and contains
-    a collection of :class:`~labapi.entry.entries.base.Entry` objects. It
-    provides
-    functionalities to access and manage these entries.
+    a collection of :class:`~labapi.entry.entries.base.Entry` objects.
+    Entries are accessed through the :attr:`entries` property.
     """
 
     def __init__(
@@ -68,10 +67,7 @@ class NotebookPage(AbstractTreeNode):
 
     @property
     def entries(self) -> Entries:
-        """Return this page's entries, loading them on first access.
-
-        This property lazily loads the entries from the LabArchives API if they
-        have not been loaded yet.
+        """Return this page's entries, loading them from the API on first access.
 
         .. note::
            Slicing on the returned collection provides snapshots.
@@ -150,15 +146,11 @@ class NotebookPage(AbstractTreeNode):
         :param destination: The target container to copy the page to.
         :returns: A new instance of the copied page in the destination.
 
-        Copy behavior for attachments is explicit:
+        Attachment handling during copy:
 
         - attachment payloads are copied by reading and re-uploading the attachment content,
         - attachment resources opened during copy are always released,
         - any per-entry copy failure is reported via warning and that entry is skipped.
-
-        .. note::
-           This method is best-effort and may produce partial copies if one or more
-           entries fail while others succeed.
 
         :raises RuntimeWarning: Emitted when an individual entry fails to copy.
         """
@@ -206,8 +198,8 @@ class NotebookPage(AbstractTreeNode):
         to re-fetch its entries from the LabArchives API on the next access.
 
         .. note::
-           Currently only clears the entries cache. Future implementation should
-           properly invalidate all entry objects before clearing.
+           Entry objects obtained before the refresh are not invalidated and
+           may be stale.
         """
         # TODO: Properly invalidate all entry objects before clearing
         self._entries = None

--- a/src/labapi/user.py
+++ b/src/labapi/user.py
@@ -1,9 +1,7 @@
 """LabArchives User Module.
 
 This module defines the :class:`~labapi.user.User` class, which represents an
-authenticated user session with the LabArchives API. It provides methods for
-interacting with the API on behalf of the user, managing notebooks, and
-accessing user-specific information.
+authenticated user session with the LabArchives API.
 """
 
 from __future__ import annotations
@@ -52,26 +50,17 @@ class User:
 
     @property
     def id(self) -> str:
-        """The unique ID of the user.
-
-        :returns: The user's ID.
-        """
+        """The unique ID of the user."""
         return self._id
 
     @property
     def email(self) -> str:
-        """The email address of the user.
-
-        :returns: The user's email.
-        """
+        """The email address of the user."""
         return self._email
 
     @property
     def client(self) -> Client:
-        """The :class:`~labapi.client.Client` instance associated with this user session.
-
-        :returns: The client instance.
-        """
+        """The :class:`~labapi.client.Client` instance associated with this user session."""
         return self._client
 
     def api_get(self, api_method_uri: str | Sequence[str], **kwargs: Any):
@@ -121,8 +110,6 @@ class User:
     def get_max_upload_size(self) -> int:
         """Return the maximum upload size for this user in bytes.
 
-        The unit of the returned value is bytes.
-
         :returns: The maximum upload size in bytes.
         :raises RuntimeError: If the underlying client session has been closed.
         :raises AuthenticationError: If LabArchives rejects the request due to
@@ -139,7 +126,7 @@ class User:
 
     @property
     def notebooks(self) -> Notebooks:
-        """Provides access to the user's notebooks.
+        """The user's notebooks.
 
         :returns: A :class:`~labapi.tree.collection.Notebooks` object managing the user's notebooks.
         """

--- a/src/labapi/util/extract.py
+++ b/src/labapi/util/extract.py
@@ -1,8 +1,7 @@
-"""XML Extraction Utilities Module.
+"""Utilities for extracting data from ``lxml.etree.Element`` objects.
 
-This module provides utility functions for extracting data from `lxml.etree.Element`
-objects, including flattening dictionaries for easier processing, converting
-strings to booleans, and a general-purpose XML extraction function.
+Includes flattening nested extractor dictionaries, converting strings to
+booleans, and a general-purpose XML extraction function.
 """
 
 from __future__ import annotations

--- a/src/labapi/util/types.py
+++ b/src/labapi/util/types.py
@@ -1,8 +1,4 @@
-"""Types Module.
-
-This module defines enumeration classes and data types used throughout
-the LabArchives API client.
-"""
+"""Enumeration classes and data types shared across the LabArchives API client."""
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -47,24 +43,21 @@ Example: ``Index.Name:"some_name"``
 
 IdOrNameIndex: TypeAlias = "str | IdIndex | NameIndex"
 """
-Type alias representing a flexible index that can be either an item's ID (string),
-or a slice using :attr:`Index.Id` or :attr:`Index.Name`.
+Type alias for an index: either an item's ID (string), or a slice using
+:attr:`Index.Id` or :attr:`Index.Name`.
 """
 
 
 @dataclass
 class NotebookInit:
-    """Represents the initial data required to set up a LabArchives notebook object.
-
-    This dataclass holds essential information such as the notebook's ID, and name.
-    """
+    """Represents the initial data required to set up a LabArchives notebook object."""
 
     id: str
     """The unique identifier of the notebook."""
     name: str
     """The name of the notebook."""
     is_default: bool
-    """A value indicating if this notebook is the user's default."""
+    """Whether this notebook is the user's default."""
 
 
 JsonData: TypeAlias = (


### PR DESCRIPTION
## Summary
- Mirror the 1.1 documentation refresh into main.
- Bring over README, Sphinx docs, and API docstring wording updates.
- Leave release metadata and dependency files unchanged because main already mirrors them.

## Validation
- uv run --python 3.10 sphinx-build -b html docs/source docs/_build/html
- .venv\Scripts\ruff.exe check on touched Python files
- Commit hooks: Pyright, ruff check, ruff format