### PR TITLE
fix: validate str type in text entry content setter

### DIFF
--- a/src/labapi/entry/entries/text.py
+++ b/src/labapi/entry/entries/text.py
@@ -52,6 +52,9 @@ class PlainTextEntry(Entry[str], part_type="plain text entry"):
 
         :param value: The new text content for the entry.
         """
+        if not isinstance(value, str):
+            raise TypeError(f"content must be a str, got {type(value).__name__}")
+
         self._user.api_post("entries/update_entry", {"entry_data": value}, eid=self.id)
 
         self._data = value

--- a/tests/entry/entries/test_text.py
+++ b/tests/entry/entries/test_text.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pytest
+
 from labapi.entry.entries.text import HeaderEntry, PlainTextEntry, TextEntry
 from labapi.user import User
 
@@ -52,6 +54,28 @@ class TestTextEntryUnit:
         entry = PlainTextEntry("eid_plain", "This is plain text", mock_user)
 
         assert entry.content == "This is plain text"
+
+    def test_content_setter_rejects_none(self):
+        """Test that setting content to None raises TypeError."""
+        mock_user = Mock(spec=User)
+        entry = TextEntry("eid_text", "original", mock_user)
+
+        with pytest.raises(TypeError, match="content must be a str, got NoneType"):
+            entry.content = None  # type: ignore[assignment]  # intentional bad type
+
+        mock_user.api_post.assert_not_called()
+        assert entry.content == "original"
+
+    def test_content_setter_rejects_non_str(self):
+        """Test that setting content to a non-str raises TypeError."""
+        mock_user = Mock(spec=User)
+        entry = PlainTextEntry("eid_plain", "original", mock_user)
+
+        with pytest.raises(TypeError, match="content must be a str, got int"):
+            entry.content = 42  # type: ignore[assignment]  # intentional bad type
+
+        mock_user.api_post.assert_not_called()
+        assert entry.content == "original"
 
 
 class TestTextEntryIntegration:


### PR DESCRIPTION
## Summary

Add a runtime type guard to `PlainTextEntry.content` setter so that assigning a non-`str` value raises `TypeError` immediately — before the API call is made or the local cache is mutated.

## Problem

The setter's type annotation declares `value: str`, but there was no runtime enforcement. Assigning `None` (or any non-str) would:

1. Fire an API call with `{"entry_data": None}`, which `requests` form-encodes by omitting the field entirely — undefined server behavior.
2. Cache the invalid value in `self._data`, so subsequent reads of `.content` return `None` instead of `str`, violating the return type contract.

## Fix

`isinstance(value, str)` check at the top of the setter, following the same pattern used in `Entries.create` ([collection.py:206-209](https://github.com/nimh-dsst/labapi/blob/main/src/labapi/entry/collection.py#L206-L209)).

## Tests

Two new unit tests in `test_text.py`:
- `test_content_setter_rejects_none` — `None` → `TypeError`, no API call, cache unchanged
- `test_content_setter_rejects_non_str` — `int` → `TypeError`, no API call, cache unchanged

Closes #225