### PR TITLE
fix: sanitize sensitive query params in ApiError URLs

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -433,9 +433,16 @@ class Client:
                     raise AuthenticationError(message, error_code)
                 raise ApiError(message, error_code)
 
+            parts = urlsplit(response.url)
+            query = dict(parse_qsl(parts.query, keep_blank_values=True))
+            for key in {"akid", "sig", "expires", "password", "login_or_email"}:
+                if key in query:
+                    query[key] = "***"
+            clean_url = urlunsplit(parts._replace(query=urlencode(query)))
+
             raise ApiError(
                 f"API request failed with status code {response.status_code} "
-                f"for URL {response.url}: {response.text}"
+                f"for URL {clean_url}: {response.text}"
             )
 
     def stream_api_get(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -349,6 +349,24 @@ class TestClientUnit:
         with pytest.raises(ApiError, match="API request failed with status code 404"):
             Client._handle_request_status(response)
 
+    def test_client_handle_request_status_sanitizes_url(self):
+        """Test Client._handle_request_status sanitizes sensitive query params."""
+        response = Mock(spec=Response)
+        response.status_code = 500
+        response.url = "https://api.test.com/endpoint?akid=secret&password=pass&sig=123&normal=true"
+        response.text = "Internal Error"
+
+        with pytest.raises(ApiError) as exc_info:
+            Client._handle_request_status(response)
+
+        error_msg = str(exc_info.value)
+        assert "akid=%2A%2A%2A" in error_msg
+        assert "password=%2A%2A%2A" in error_msg
+        assert "sig=%2A%2A%2A" in error_msg
+        assert "normal=true" in error_msg
+        assert "=secret" not in error_msg
+        assert "=pass" not in error_msg
+
     def test_raw_api_get_returns_response(self):
         """Test raw_api_get returns the raw response and calls session.get directly."""
         client = Client("https://api.test.com", "test_akid", "test_password")


### PR DESCRIPTION
## Summary

Sanitizes sensitive query parameters (`akid`, `sig`, `expires`, `password`, `login_or_email`) from the request URL before including it in the `ApiError` fallback message.

## Problem

When the API returns a non-200 response and the body cannot be parsed as XML (such as a 500 internal server error or a WAF block), `Client._handle_request_status` falls back to generating a generic error message that includes `response.url`.

This URL includes all query parameters sent with the request, including the access key ID (`akid`), request signature (`sig`), and potentially sensitive data like `password` or `login_or_email` for certain endpoints. This results in sensitive authentication tokens being leaked in application logs and tracebacks.

## Fix

Before formatting the URL into the `ApiError` message, the URL is parsed, sensitive query parameters are masked with `***`, and the URL is reconstructed.

A new unit test `test_client_handle_request_status_sanitizes_url` was added to verify this behavior.

Closes #217