### PR TITLE
fix: override __contains__ in tree containers to fix Index.Name membership

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -499,7 +499,7 @@ class AbstractTreeContainer(
         :returns: True if the key is found and not empty, False otherwise.
         """
         try:
-            return bool(self[key])  # type: ignore[index]
+            return bool(self[key])  # type: ignore  # pyright: ignore[reportArgumentType]
         except (KeyError, TypeError):
             return False
 

--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -492,6 +492,17 @@ class AbstractTreeContainer(
         """
         return iter(node.name for node in self.children)
 
+    def __contains__(self, key: object) -> bool:
+        """Return whether the container contains the given key.
+
+        :param key: The key or indexed selector to check for.
+        :returns: True if the key is found and not empty, False otherwise.
+        """
+        try:
+            return bool(self[key])  # type: ignore[index]
+        except (KeyError, TypeError):
+            return False
+
     @override
     def keys(self) -> KeysView[str]:
         """Return a mapping-compatible view of child names."""

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -285,6 +285,17 @@ class TestTreeMixinsIntegration:
         _ = client.pop_api_call()  # update_node for name
         _ = client.pop_api_call()  # update_node for move
 
+    def test_contains(self, notebook_tree: Notebook):
+        """Test __contains__ handles strings and indexed slices properly."""
+        assert "Test Folder A" in notebook_tree
+        assert "Missing Folder" not in notebook_tree
+
+        assert slice(Index.Id, "dir-1") in notebook_tree
+        assert slice(Index.Id, "missing-id") not in notebook_tree
+
+        assert slice(Index.Name, "Test Folder A") in notebook_tree
+        assert slice(Index.Name, "Missing Folder") not in notebook_tree
+
     def test_mapping_methods(self, notebook_tree: Notebook):
         """Test keys(), values(), and items() on a container."""
         keys = notebook_tree.keys()


### PR DESCRIPTION
## Summary

Fixes a bug where checking for membership of a non-existent child using an `Index.Name` slice returned `True`.

## Problem

Because `AbstractTreeContainer` inherits from Python's `Mapping`, it falls back to a default `__contains__` implementation that catches `KeyError`. 

When querying a container using `Index.Name` (e.g. `container[Index.Name:"missing"]`), the `__getitem__` method returns an empty list `[]` rather than raising a `KeyError`. This causes the default `__contains__` to assume the element exists and return `True`.

## Fix

Explicitly implemented `__contains__` on `AbstractTreeContainer`. It attempts to evaluate the truthiness of `self[key]` and falls back to `False` for `KeyError` or `TypeError`.

This correctly handles both single nodes (`Index.Id`, exact string matches) and multiple nodes (`Index.Name` slices), correctly evaluating an empty list as `False`.

Closes #224