### PR TITLE
fix: change auth callback handler base class to BaseHTTPRequestHandler

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -12,7 +12,7 @@ from base64 import b64encode
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import suppress
 from datetime import datetime, timedelta
-from http.server import SimpleHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler
 from operator import itemgetter
 from secrets import token_urlsafe
 from socketserver import TCPServer
@@ -154,7 +154,7 @@ class _AuthResponseCollector:
         collector = self
         callback_path = self._callback_path
 
-        class AuthRequestHandler(SimpleHTTPRequestHandler):
+        class AuthRequestHandler(BaseHTTPRequestHandler):
             def _write_response(self, status_code: int, message: str) -> None:
                 self.send_response(status_code)
                 self.send_header("Content-type", "text/html")

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -161,7 +161,6 @@ class _AuthResponseCollector:
                 self.end_headers()
                 self.wfile.write(message.encode("utf-8"))
 
-            @override
             def do_GET(self) -> None:
                 _scheme, _netloc, path, querystring, _fragment = urlsplit(self.path)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -686,6 +686,34 @@ class TestClientUnit:
         assert result["user"] is login.return_value
         login.assert_called_once_with("user@example.com", "good-code")
 
+    def test_collect_auth_response_rejects_head_request(self):
+        """Test auth callback collector rejects HEAD requests with 501."""
+        client = Client("https://api.test.com", "test_akid", "test_password")
+        port = reserve_local_port()
+        errors: list[BaseException] = []
+
+        def run_collect_auth_response() -> None:
+            try:
+                with client.collect_auth_response(port=port, timeout=1.0) as collector:
+                    collector.wait()
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = Thread(target=run_collect_auth_response, daemon=True)
+        thread.start()
+        wait_for_local_listener(port)
+
+        connection = HTTPConnection("127.0.0.1", port, timeout=2)
+        try:
+            connection.request("HEAD", "/pyproject.toml")
+            response = connection.getresponse()
+            assert response.status == 501
+            response.read()
+        finally:
+            connection.close()
+
+        thread.join(timeout=2)
+
     def test_stream_api_get_yields_chunks_and_returns_response(self):
         """Test stream_api_get yields streamed chunks and returns the response."""
         client = Client("https://api.test.com", "test_akid", "test_password")


### PR DESCRIPTION
## Summary

Changes the base class of `AuthRequestHandler` to `BaseHTTPRequestHandler` to prevent local file metadata leakage via `HEAD` requests during the authentication window.

## Problem

The local HTTP server spun up to catch the OAuth callback inherited from `SimpleHTTPRequestHandler`. While it correctly overrode `do_GET` to handle the callback, it left the default `do_HEAD` method exposed. 

Because `SimpleHTTPRequestHandler.do_HEAD` serves metadata for files in the current working directory, any local process (or anyone on the local network, if the port was exposed) could issue `HEAD` requests to the callback port during the auth window and discover the existence, size, and last modified timestamps of sensitive files.

## Fix

Replaced `SimpleHTTPRequestHandler` with `BaseHTTPRequestHandler`. This minimal base class does not implement any file-serving methods by default. It responds to unspecified verbs (like `HEAD`) with a `501 Unsupported method` status code, closing the vulnerability. 

A unit test was added to explicitly verify that `HEAD` requests are rejected with a 501.

Closes #228