### PR TITLE
fix: change auth callback response to text/plain to prevent XSS

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -157,7 +157,7 @@ class _AuthResponseCollector:
         class AuthRequestHandler(SimpleHTTPRequestHandler):
             def _write_response(self, status_code: int, message: str) -> None:
                 self.send_response(status_code)
-                self.send_header("Content-type", "text/html")
+                self.send_header("Content-type", "text/plain")
                 self.end_headers()
                 self.wfile.write(message.encode("utf-8"))
 


### PR DESCRIPTION
## Summary

Changes the `Content-Type` of the local auth callback response from `text/html` to `text/plain` to prevent Cross-Site Scripting (XSS).

## Problem

The local OAuth callback server previously served responses with a `text/html` Content-Type. When an error occurred, the error message from the query string (`?error=...`) was interpolated directly into the response body without HTML escaping.

This allowed a malicious page or a tricked user to trigger XSS in the loopback server's context, potentially executing arbitrary JavaScript if they clicked a malicious link to `http://127.0.0.1:8093/auth/?error=<script>...`.

## Fix

Since the response doesn't actually require any HTML rendering, the `Content-Type` was safely downgraded to `text/plain` to mitigate this without adding HTML-escaping overhead.

Closes #227