### PR TITLE
fix: default to secure unguessable loopback callback path

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -45,7 +45,7 @@ _AUTH_ERROR_CODES: frozenset[int] = frozenset(
 
 _DEFAULT_AUTH_CALLBACK_HOST = "127.0.0.1"
 _DEFAULT_AUTH_CALLBACK_PORT = 8089
-_DEFAULT_AUTH_CALLBACK_PATH = "/"
+
 _DEFAULT_AUTH_CALLBACK_TIMEOUT = 300.0
 
 
@@ -136,13 +136,13 @@ class _AuthResponseCollector:
         client: Client,
         *,
         port: int = _DEFAULT_AUTH_CALLBACK_PORT,
-        callback_path: str = _DEFAULT_AUTH_CALLBACK_PATH,
+        callback_path: str | None = None,
         timeout: float | None = _DEFAULT_AUTH_CALLBACK_TIMEOUT,
     ):
         """Initialize a loopback auth callback collector."""
         self._client = client
         self._port = port
-        self._callback_path = callback_path
+        self._callback_path = callback_path or f"/auth/{token_urlsafe(24)}/"
         self._timeout = timeout
         self._error: str | None = None
         self._email: str | None = None
@@ -683,7 +683,7 @@ class Client:
         self,
         *,
         port: int = _DEFAULT_AUTH_CALLBACK_PORT,
-        callback_path: str = _DEFAULT_AUTH_CALLBACK_PATH,
+        callback_path: str | None = None,
         timeout: float | None = _DEFAULT_AUTH_CALLBACK_TIMEOUT,
     ) -> _AuthResponseCollector:
         """Return a context manager for collecting a loopback auth callback.
@@ -699,7 +699,7 @@ class Client:
         :returns: An enterable collector with a ``wait()`` method for the authentication callback.
         """
         self._ensure_open()
-        if not callback_path.startswith("/"):
+        if callback_path is not None and not callback_path.startswith("/"):
             callback_path = f"/{callback_path}"
 
         return _AuthResponseCollector(


### PR DESCRIPTION
## Summary

Updates `collect_auth_response` to dynamically generate an unguessable callback path by default, closing a nonce bypass vulnerability.

## Problem

While `Client.authenticate()` generated a secure unguessable callback path (using `secrets.token_urlsafe(24)`), the underlying `Client.collect_auth_response()` function defaulted to `/` if called directly without a `callback_path`. 

If a developer built their own custom OAuth flow using `collect_auth_response()` but forgot to generate their own unguessable path, their application became vulnerable to local attackers intercepting the auth flow by hitting the `/` loopback port during the auth window.

## Fix

The static `_DEFAULT_AUTH_CALLBACK_PATH` was removed, and `collect_auth_response` now defaults `callback_path` to `None`. When `None` is provided, `_AuthResponseCollector` automatically generates a 24-byte url-safe random path. This ensures all consumers of this API get a secure default behavior that cannot be easily bypassed by local blind requests.

Closes #226