### PR TITLE
fix: preserve first matching child for duplicate names in mapping views

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -492,23 +492,30 @@ class AbstractTreeContainer(
         """
         return iter(node.name for node in self.children)
 
+    def _mapping_view_dict(self) -> dict[str, AbstractBaseTreeNode]:
+        d: dict[str, AbstractBaseTreeNode] = {}
+        for node in self.children:
+            if node.name not in d:
+                d[node.name] = node
+        return d
+
     @override
     def keys(self) -> KeysView[str]:
         """Return a mapping-compatible view of child names."""
         self._ensure_populated()
-        return KeysView({node.name: node for node in self.children})
+        return KeysView(self._mapping_view_dict())
 
     @override
     def items(self) -> ItemsView[str, AbstractBaseTreeNode]:
         """Return a mapping-compatible view of ``(name, child)`` pairs."""
         self._ensure_populated()
-        return ItemsView({node.name: node for node in self.children})
+        return ItemsView(self._mapping_view_dict())
 
     @override
     def values(self) -> ValuesView[AbstractBaseTreeNode]:
         """Return a mapping-compatible view of child nodes."""
         self._ensure_populated()
-        return ValuesView({node.name: node for node in self.children})
+        return ValuesView(self._mapping_view_dict())
 
     def all_keys(self) -> Sequence[str]:
         """Return child names in container order, preserving duplicates."""

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -298,6 +298,32 @@ class TestTreeMixinsIntegration:
         items = notebook_tree.items()
         assert ("Test Folder A", notebook_tree[Index.Id : "dir-1"]) in items
 
+    def test_standard_mapping_methods_preserve_first_matching_child(
+        self, notebook_tree: Notebook
+    ):
+        """Test keys(), values(), and items() preserve the first matching child."""
+        duplicate_page = NotebookPage(
+            "page-duplicate",
+            "Test Page 1",
+            notebook_tree,
+            notebook_tree,
+            notebook_tree.user,
+        )
+        notebook_tree._children.append(duplicate_page)  # pyright: ignore[reportPrivateUsage]
+
+        keys = notebook_tree.keys()
+        # dict keys are unique, so there should be only one "Test Page 1"
+        assert len(keys) == 3
+        assert "Test Page 1" in keys
+
+        values = list(notebook_tree.values())
+        # Should contain the original page-1, not page-duplicate
+        assert any(node.id == "page-1" for node in values)
+        assert all(node.id != "page-duplicate" for node in values)
+
+        items = dict(notebook_tree.items())
+        assert items["Test Page 1"].id == "page-1"
+
     def test_duplicate_mapping_methods_preserve_duplicate_names(
         self, notebook_tree: Notebook
     ):


### PR DESCRIPTION
## Summary

Fixes inconsistent behavior where `keys()`, `values()`, and `items()` on tree containers returned the last matching child for duplicate names, while `__getitem__` returned the first match.

## Problem

Tree containers can technically have multiple children with the same name. `__getitem__` returns the first one it encounters. However, the mapping views were being generated via dictionary comprehension: `{node.name: node for node in self.children}`. Since dictionaries overwrite duplicate keys, the last matching node won out. This resulted in an inconsistency between `container["duplicate"]`, which returns the first item, and `container.values()`, which returned the last.

## Fix

Introduced a private `_mapping_view_dict` helper that manually constructs the dictionary, explicitly ignoring subsequent children with names that are already present in the dictionary. This ensures that the first matching child is retained across all mapping views, preserving consistency with `__getitem__`.

Closes #223