### PR TITLE
fix: restrict ImportError catching in authenticate to browser setup

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -642,25 +642,32 @@ class Client:
             timeout=timeout,
         ) as auth_response_collector:
             try:
-                match detect_default_browser():
-                    case "chrome":
-                        import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
+                try:
+                    match detect_default_browser():
+                        case "chrome":
+                            import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
 
-                        driver = webdriver.Chrome(options=webdriver.ChromeOptions())
-                        print("Opening Chrome for authentication...")
-                    case "firefox":
-                        import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
+                            driver = webdriver.Chrome(options=webdriver.ChromeOptions())
+                            print("Opening Chrome for authentication...")
+                        case "firefox":
+                            import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
 
-                        driver = webdriver.Firefox(options=webdriver.FirefoxOptions())
-                        print("Opening Firefox for authentication...")
-                    case "edge":
-                        import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
+                            driver = webdriver.Firefox(options=webdriver.FirefoxOptions())
+                            print("Opening Firefox for authentication...")
+                        case "edge":
+                            import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
 
-                        driver = webdriver.Edge(options=webdriver.EdgeOptions())
-                        print("Opening Edge for authentication...")
-                    case "terminal":
-                        print("Open authentication URL in your browser:")
-                        print(auth_url)
+                            driver = webdriver.Edge(options=webdriver.EdgeOptions())
+                            print("Opening Edge for authentication...")
+                        case "terminal":
+                            print("Open authentication URL in your browser:")
+                            print(auth_url)
+                except ImportError as e:
+                    raise ImportError(
+                        "The builtin-auth dependencies are required for automatic browser-based authentication. "
+                        "Install with: pip install labapi[builtin-auth]\n"
+                        "Alternatively, use manual authentication with LA_AUTH_BROWSER=terminal."
+                    ) from e
 
                 if driver is not None:
                     driver.get(auth_url)
@@ -669,12 +676,6 @@ class Client:
                     )
 
                 return auth_response_collector.wait()
-            except ImportError as e:
-                raise ImportError(
-                    "The builtin-auth dependencies are required for automatic browser-based authentication. "
-                    "Install with: pip install labapi[builtin-auth]\n"
-                    "Alternatively, use manual authentication with LA_AUTH_BROWSER=terminal."
-                ) from e
             finally:
                 if driver is not None:
                     driver.quit()

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -652,7 +652,9 @@ class Client:
                         case "firefox":
                             import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]
 
-                            driver = webdriver.Firefox(options=webdriver.FirefoxOptions())
+                            driver = webdriver.Firefox(
+                                options=webdriver.FirefoxOptions()
+                            )
                             print("Opening Firefox for authentication...")
                         case "edge":
                             import selenium.webdriver as webdriver  # pyright: ignore[reportMissingImports]


### PR DESCRIPTION
## Summary

The `authenticate` method previously caught `ImportError` across the entire execution block, including `driver.get()` and the blocking `auth_response_collector.wait()`.

## Problem

If a custom login callback handler deep inside `wait()` or a subsequent API request raised an `ImportError` for an unrelated reason, the error was incorrectly intercepted and rewritten as a message instructing the user to install `labapi[builtin-auth]`.

## Fix

This tightens the scope of the `try...except ImportError` block to only surround the `detect_default_browser()` match block, ensuring that any `ImportError` raised during the wait or network execution propagates naturally without being swallowed.

Closes #230