### PR TITLE
fix: use response.content for XML parsing to preserve original encoding

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -419,7 +419,7 @@ class Client:
             error_code: int | None = None
             error_desc: str | None = None
             try:
-                tree = fromstring(bytes(response.text, encoding="utf-8"))
+                tree = fromstring(response.content)
                 code_text = tree.findtext("./error-code")
                 if code_text is not None:
                     error_code = int(code_text)


### PR DESCRIPTION
## Summary

When parsing error XML in `_handle_request_status`, the code previously used `bytes(response.text, encoding="utf-8")`.

## Problem

If the server returned XML with an explicit encoding declaration like `ISO-8859-1`, `response.text` would correctly decode the payload using that encoding into a standard string. However, explicitly re-encoding it to UTF-8 bytes to pass to `lxml` without changing the XML declaration meant that `lxml` was fed UTF-8 bytes but instructed by the XML preamble to decode them as ISO-8859-1. This severely mangled non-ASCII text in error messages.

## Fix

By using `response.content` directly, `lxml` receives the raw bytes exactly as they were sent from the server. This ensures the embedded XML encoding declaration matches the actual bytes being parsed, which allows `lxml` to decode the payload flawlessly.

Closes #229
