### PR TITLE
fix: raise PartialEntryCreateError when create_json_entry orphans attachment

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -119,16 +119,24 @@ class Entries(Sequence["Entry[Any]"]):
             ),
         )
 
-        text_entry = self.create(
-            TextEntry,
-            f"""
+        try:
+            text_entry = self.create(
+                TextEntry,
+                f"""
 <p>Reference Attachment: {escape(display_caption)}</p>
 <p>Entry ID: {escape(file_entry.id)}</p>
 <pre>
 {preview_json}
 </pre>
 """,
-        )
+            )
+        except Exception as e:
+            from labapi.exceptions import PartialEntryCreateError
+
+            raise PartialEntryCreateError(
+                f"Failed to create companion text entry for attachment {file_entry.id}",
+                partial_entry=file_entry,
+            ) from e
         return file_entry, text_entry
 
     @overload

--- a/src/labapi/exceptions.py
+++ b/src/labapi/exceptions.py
@@ -78,3 +78,16 @@ class ExtractionError(LabArchivesError, ValueError):
 
 class TreeChildParseError(ExtractionError):
     """A tree child node could not be parsed from a tree-level response."""
+
+
+class PartialEntryCreateError(LabArchivesError):
+    """An entry was partially created but subsequent operations failed.
+
+    ``partial_entry`` contains the successfully created entry object, which
+    has already been added to the local collection and remote server.
+    """
+
+    def __init__(self, message: str, partial_entry: "labapi.entry.entries.base.BaseEntry") -> None:
+        """Initialize a partial entry create error."""
+        super().__init__(message)
+        self.partial_entry = partial_entry

--- a/src/labapi/exceptions.py
+++ b/src/labapi/exceptions.py
@@ -1,5 +1,10 @@
 """Custom exception types raised by ``labapi``."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from labapi.entry.entries.base import BaseEntry
+
 
 class LabArchivesError(Exception):
     """Base for all ``labapi`` exceptions."""
@@ -87,9 +92,7 @@ class PartialEntryCreateError(LabArchivesError):
     has already been added to the local collection and remote server.
     """
 
-    def __init__(
-        self, message: str, partial_entry: "labapi.entry.entries.base.BaseEntry"
-    ) -> None:
+    def __init__(self, message: str, partial_entry: "BaseEntry") -> None:
         """Initialize a partial entry create error."""
         super().__init__(message)
         self.partial_entry = partial_entry

--- a/src/labapi/exceptions.py
+++ b/src/labapi/exceptions.py
@@ -87,7 +87,9 @@ class PartialEntryCreateError(LabArchivesError):
     has already been added to the local collection and remote server.
     """
 
-    def __init__(self, message: str, partial_entry: "labapi.entry.entries.base.BaseEntry") -> None:
+    def __init__(
+        self, message: str, partial_entry: "labapi.entry.entries.base.BaseEntry"
+    ) -> None:
         """Initialize a partial entry create error."""
         super().__init__(message)
         self.partial_entry = partial_entry

--- a/src/labapi/exceptions.py
+++ b/src/labapi/exceptions.py
@@ -1,9 +1,9 @@
 """Custom exception types raised by ``labapi``."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from labapi.entry.entries.base import BaseEntry
+    from labapi.entry.entries.base import Entry
 
 
 class LabArchivesError(Exception):
@@ -92,7 +92,7 @@ class PartialEntryCreateError(LabArchivesError):
     has already been added to the local collection and remote server.
     """
 
-    def __init__(self, message: str, partial_entry: "BaseEntry") -> None:
+    def __init__(self, message: str, partial_entry: "Entry[Any]") -> None:
         """Initialize a partial entry create error."""
         super().__init__(message)
         self.partial_entry = partial_entry


### PR DESCRIPTION
## Summary

When `create_json_entry` attempts to create the JSON attachment and its companion text entry, it does so sequentially. If the companion text entry creation fails (e.g., due to a network error), the initially uploaded JSON attachment is orphaned on the server, and the caller receives a raw exception with no handle to the attachment.

## Fix

Since there is currently no API support for rolling back the creation (deleting the entry), this PR catches the failure and explicitly raises a new `PartialEntryCreateError`. This error wraps the underlying exception and includes the successfully created attachment entry in its `partial_entry` attribute.

This ensures the caller can explicitly access the partial attachment and handles the failure gracefully while preserving consistency with the local collection state (which has already appended the attachment).

Closes #218
