### PR TITLE
fix: preserve first matching notebook in Notebooks mapping views

### DIFF
--- a/src/labapi/tree/collection.py
+++ b/src/labapi/tree/collection.py
@@ -99,13 +99,20 @@ class Notebooks(Mapping[IdOrNameIndex, Notebook | Sequence[Notebook]]):
         """Return the number of notebooks in this collection."""
         return len(self._notebooks)
 
+    def _mapping_view_dict(self) -> dict[str, Notebook]:
+        d: dict[str, Notebook] = {}
+        for n in self._notebooks:
+            if n.name not in d:
+                d[n.name] = n
+        return d
+
     @override
     def keys(self) -> KeysView[str]:
         """Return a mapping-compatible view of notebook names.
 
         :returns: A keys view of notebook names.
         """
-        return KeysView({n.name: n for n in self._notebooks})
+        return KeysView(self._mapping_view_dict())
 
     @override
     def items(self) -> ItemsView[str, Notebook]:
@@ -113,7 +120,7 @@ class Notebooks(Mapping[IdOrNameIndex, Notebook | Sequence[Notebook]]):
 
         :returns: An items view of ``(name, notebook)`` pairs.
         """
-        return ItemsView({n.name: n for n in self._notebooks})
+        return ItemsView(self._mapping_view_dict())
 
     @override
     def values(self) -> ValuesView[Notebook]:
@@ -121,7 +128,7 @@ class Notebooks(Mapping[IdOrNameIndex, Notebook | Sequence[Notebook]]):
 
         :returns: A values view of notebook objects.
         """
-        return ValuesView({n.name: n for n in self._notebooks})
+        return ValuesView(self._mapping_view_dict())
 
     def all_keys(self) -> Sequence[str]:
         """Return notebook names in collection order, preserving duplicates."""

--- a/tests/tree/test_collection.py
+++ b/tests/tree/test_collection.py
@@ -124,13 +124,39 @@ class TestNotebooksUnit:
         assert set(keys) == {"Shared", "Unique"}
 
         values = notebooks.values()
-        assert [notebook.id for notebook in values] == ["nb2", "nb3"]
+        assert [notebook.id for notebook in values] == ["nb1", "nb3"]
 
         items = notebooks.items()
         assert [(name, notebook.id) for name, notebook in items] == [
-            ("Shared", "nb2"),
+            ("Shared", "nb1"),
             ("Unique", "nb3"),
         ]
+
+    def test_notebooks_mapping_views_preserve_first_match_for_duplicates(self):
+        """Test that keys/items/values agree with getitem for duplicate names (#214).
+
+        keys(), items(), and values() must retain the *first* notebook when
+        there are duplicate names, matching the behaviour of __getitem__.
+        """
+        mock_user = Mock(spec=User)
+        notebooks_init = [
+            NotebookInit(id="nb1", name="dup", is_default=True),
+            NotebookInit(id="nb2", name="dup", is_default=False),
+        ]
+        notebooks = Notebooks(notebooks_init, mock_user)
+
+        # __getitem__ already returns the first match
+        assert notebooks["dup"].id == "nb1"
+
+        # mapping views must agree with __getitem__
+        keys = list(notebooks.keys())
+        assert keys == ["dup"]
+
+        values_ids = [nb.id for nb in notebooks.values()]
+        assert values_ids == ["nb1"]
+
+        items_ids = [(name, nb.id) for name, nb in notebooks.items()]
+        assert items_ids == [("dup", "nb1")]
 
     def test_notebooks_duplicate_mapping_methods_preserve_duplicate_names(self):
         """Test duplicate_* methods preserve duplicate notebook names."""


### PR DESCRIPTION
## Summary

`keys()`, `items()`, and `values()` in `Notebooks` were built using a plain dict comprehension `{n.name: n for n in self._notebooks}`, which overwrites earlier entries and retains the **last** notebook for any duplicated name. This disagreed with `__getitem__`, which returns the first match, and with `len`/`iter`.

## Fix

Add a `_mapping_view_dict` helper that inserts only the first occurrence of each name, mirroring the identical fix applied to `AbstractTreeContainer` in #237.

Also updates `test_notebooks_mapping_methods_are_mapping_compatible` which previously asserted the buggy last-match behaviour, and adds a dedicated regression test.

Closes #214