### PR TITLE
[codex] Reject unsupported entry creation wrappers

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -14,7 +14,7 @@ from typing_extensions import override
 from labapi.util import extract_etree
 
 from .attachment import Attachment
-from .entries import AttachmentEntry, Entry, TextEntry
+from .entries import AttachmentEntry, Entry, TextEntry, UnknownEntry
 
 E = TypeVar("E", bound="Entry[Any]")
 
@@ -180,6 +180,9 @@ class Entries(Sequence["Entry[Any]"]):
 
         Invalid XML propagates ``lxml.etree.XMLSyntaxError``.
         """
+        if issubclass(cls, UnknownEntry):
+            raise TypeError(f"{cls.__name__} cannot be created")
+
         if issubclass(cls, AttachmentEntry):
             if not isinstance(data, Attachment):
                 raise TypeError(

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -15,6 +15,9 @@ from labapi.entry.entries import (
     HeaderEntry,
     PlainTextEntry,
     TextEntry,
+    UnimplementedEntry,
+    UnknownEntry,
+    WidgetEntry,
 )
 from labapi.user import User
 
@@ -128,6 +131,21 @@ class TestEntriesUnit:
 
         with pytest.raises(TypeError, match="TextEntry requires str data"):
             entries.create(TextEntry, cast(Any, attachment))
+
+        mock_user.api_post.assert_not_called()
+
+    @pytest.mark.parametrize("cls", [UnknownEntry, UnimplementedEntry, WidgetEntry])
+    def test_entries_create_rejects_unsupported_wrappers(self, cls: type[Any]):
+        """Test unsupported fallback entry wrappers are rejected before API calls."""
+        mock_user = Mock(spec=User)
+        mock_page = Mock()
+        mock_page.id = "test_page_id"
+        mock_page.root = Mock()
+        mock_page.root.id = "test_notebook_id"
+        entries = Entries([], mock_user, mock_page)
+
+        with pytest.raises(TypeError, match=f"{cls.__name__} cannot be created"):
+            entries.create(cast(Any, cls), "payload")
 
         mock_user.api_post.assert_not_called()
 


### PR DESCRIPTION
## Summary
- reject unsupported fallback entry wrappers before creating entries
- prevent internal sentinel part types from being sent to `entries/add_entry`
- cover UnknownEntry, UnimplementedEntry, and WidgetEntry with no-API-call tests

Fixes #197

## Validation
- `uv run --python 3.10 pytest --no-cov tests\entry\test_collection.py`
- `uv run --python 3.10 pre-commit run --all-files`
- `uv run --python 3.10 pre-commit run --all-files --hook-stage pre-push`