### PR TITLE
fix: copy cached attachment in chunks via shutil.copyfileobj

### DIFF
--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -6,6 +6,7 @@ which represents an attachment entry within a LabArchives page.
 
 from __future__ import annotations
 
+import shutil
 from email.message import Message
 from io import BytesIO
 from tempfile import TemporaryFile
@@ -89,7 +90,7 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         # Return an independent copy so each caller gets isolated read/seek/close state
         # while still sharing a single downloaded backing attachment in the cache.
         self._filedata.seek(0)
-        output.write(self._filedata.read())
+        shutil.copyfileobj(self._filedata, output)
         output.seek(0)
 
         return Attachment(

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -169,3 +169,23 @@ class TestAttachmentEntryIntegration:
         attachment3 = entry.get_attachment()
         assert client.stream_api_get.call_count == 1
         assert attachment3.read() == b"Content"
+
+    def test_get_attachment_tempfile_copies_in_chunks(self, client, user: User):
+        """get_attachment(use_tempfile=True) must not read the full payload at once.
+
+        Regression for #215: the old code called self._filedata.read() with no
+        size, materializing the entire cached payload as one bytes object.
+        """
+        entry = AttachmentEntry("eid_att", "Caption", user)
+
+        mock_response = Mock()
+        mock_response.headers = {
+            "Content-Type": "text/plain",
+            "Content-Disposition": 'attachment; filename="test.txt"',
+        }
+        mock_response.iter_content.return_value = [b"Chunked content"]
+        client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
+
+        attachment = entry.get_attachment(use_tempfile=True)
+        assert attachment.read() == b"Chunked content"
+        attachment.close()


### PR DESCRIPTION
## Summary

`get_attachment(use_tempfile=True)` called `self._filedata.read()` with no size argument, materializing the entire cached payload as one `bytes` object before writing it to the output tempfile. This defeats the memory-saving purpose of `use_tempfile=True` for large attachments.

## Fix

Replace `output.write(self._filedata.read())` with `shutil.copyfileobj(self._filedata, output)`, which copies in bounded chunks (default 64 KB).

Closes #215