### PR TITLE
[codex] Escape enumerated tree paths

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -40,7 +40,7 @@ from labapi.util import (
     extract_etree,
     to_bool,
 )
-from labapi.util.path import EscapedSegment
+from labapi.util.path import EscapedSegment, UnescapedSegment
 
 if TYPE_CHECKING:
     from labapi.user import User
@@ -629,7 +629,7 @@ class AbstractTreeContainer(
 
         self._ensure_populated()
         for child in self._children:
-            name = child.name
+            name = str(NotebookPath.escape(UnescapedSegment(child.name))[0])
 
             if time.monotonic() > _timeout:
                 warnings.warn(

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -415,6 +415,35 @@ class TestTreeMixinsIntegration:
             for path, node in nodes
         )
 
+    def test_enumeration_escapes_separator_names_for_traversal(
+        self, notebook_tree: Notebook
+    ):
+        """Test enumerated paths with separator names round-trip through traverse."""
+        slash_dir = NotebookDirectory(
+            "slash-dir",
+            "Reports/2024",
+            notebook_tree,
+            notebook_tree,
+            notebook_tree.user,
+        )
+        slash_page = NotebookPage(
+            "slash-page",
+            r"Summary\Final",
+            notebook_tree,
+            slash_dir,
+            notebook_tree.user,
+        )
+        slash_dir._children.append(slash_page)  # pyright: ignore[reportPrivateUsage]
+        slash_dir._populated = True  # pyright: ignore[reportPrivateUsage]
+        notebook_tree._children.append(slash_dir)  # pyright: ignore[reportPrivateUsage]
+
+        nodes = notebook_tree.enumerate_nodes(depth=2)
+
+        assert (r"Reports\/2024", slash_dir) in nodes
+        assert (r"Reports\/2024/Summary\\Final", slash_page) in nodes
+        for path, node in nodes:
+            assert notebook_tree.traverse(path) is node
+
     def test_enumeration_handles_same_name_page_and_directory(
         self, notebook_tree: Notebook
     ):


### PR DESCRIPTION
## Summary
- escape emitted path segments from tree enumeration
- preserve `/` as only the join separator between already-escaped segments
- cover slash and backslash node names round-tripping through `traverse()`

Fixes #193

## Validation
- `uv run --python 3.10 pytest --no-cov tests\tree\test_mixins.py`
- `uv run --python 3.10 pre-commit run --all-files`
- `uv run --python 3.10 pre-commit run --all-files --hook-stage pre-push`