### PR TITLE
feat: add timeout parameter to Client HTTP requests

### DIFF
--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -259,6 +259,7 @@ class Client:
         akpass: bytes | str | None = None,
         *,
         strict_cert: bool = True,
+        timeout: float | tuple[float, float] | None = 60.0,
     ):
         """Initialize a LabArchives API client.
 
@@ -279,6 +280,9 @@ class Client:
                            If False, disables the VERIFY_X509_STRICT flag to allow connections
                            to servers with certificates that may not pass strict validation.
                            Defaults to True. **Warning:** Setting this to False reduces security.
+        :param timeout: How many seconds to wait for the server to send data before giving up.
+                        Can be a float, a (connect timeout, read timeout) tuple, or None to
+                        wait indefinitely. Defaults to 60.0 seconds.
         """
         super().__init__()
 
@@ -311,6 +315,7 @@ class Client:
             bytes(akpass, "utf8") if isinstance(akpass, str) else akpass, SHA512()
         )
         self.session = Session()
+        self.timeout = timeout
         self._closed = False
         if not strict_cert:
             self.session.mount("https://", _313HTTPAdapter())
@@ -458,7 +463,9 @@ class Client:
         """
         self._ensure_open()
         request = self.session.get(
-            self.construct_url(api_method_uri, query=kwargs), stream=True
+            self.construct_url(api_method_uri, query=kwargs),
+            stream=True,
+            timeout=self.timeout,
         )
         try:
             Client._handle_request_status(request)
@@ -492,7 +499,10 @@ class Client:
         """
         self._ensure_open()
         request = self.session.post(
-            self.construct_url(api_method_uri, query=kwargs), data=body, stream=True
+            self.construct_url(api_method_uri, query=kwargs),
+            data=body,
+            stream=True,
+            timeout=self.timeout,
         )
         try:
             Client._handle_request_status(request)
@@ -521,7 +531,9 @@ class Client:
         :raises ApiError: If LabArchives returns any other non-success response.
         """
         self._ensure_open()
-        request = self.session.get(self.construct_url(api_method_uri, query=kwargs))
+        request = self.session.get(
+            self.construct_url(api_method_uri, query=kwargs), timeout=self.timeout
+        )
         Client._handle_request_status(request)
 
         return request
@@ -550,7 +562,9 @@ class Client:
         """
         self._ensure_open()
         request = self.session.post(
-            self.construct_url(api_method_uri, query=kwargs), data=body
+            self.construct_url(api_method_uri, query=kwargs),
+            data=body,
+            timeout=self.timeout,
         )
         Client._handle_request_status(request)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -361,6 +361,7 @@ class TestClientUnit:
         called_url = client.session.get.call_args.args[0]
         assert "users/get_info" in called_url
         assert "uid=123" in called_url
+        assert client.session.get.call_args.kwargs["timeout"] == 60.0
 
     def test_raw_api_post_returns_response(self):
         """Test raw_api_post returns the raw response and passes the request body."""
@@ -375,6 +376,17 @@ class TestClientUnit:
         called_url = client.session.post.call_args.args[0]
         assert "entries/add_entry" in called_url
         assert client.session.post.call_args.kwargs["data"] == body
+        assert client.session.post.call_args.kwargs["timeout"] == 60.0
+
+    def test_client_custom_timeout_passed_to_requests(self):
+        """Test custom timeout is respected by request methods."""
+        client = Client("https://api.test.com", "akid", "pass", timeout=5.0)
+
+        response = make_response(200, "<xml/>")
+        client.session.get = Mock(return_value=response)
+
+        client.raw_api_get("test")
+        assert client.session.get.call_args.kwargs["timeout"] == 5.0
 
     def test_raw_api_get_raises_api_error_from_xml_error_body(self):
         """Test raw_api_get surfaces LabArchives XML error payloads."""
@@ -701,6 +713,7 @@ class TestClientUnit:
         assert chunks == [b"chunk-1", b"chunk-2"]
         assert stream.response is response
         assert stream.headers == {"Content-Type": "application/octet-stream"}
+        assert client.session.get.call_args.kwargs["timeout"] == 60.0
 
     def test_stream_api_get_raises_api_error_before_yielding_chunks(self):
         """Test stream_api_get raises before yielding when the response is not OK."""


### PR DESCRIPTION
## Summary

Client HTTP requests (`raw_api_get`, `raw_api_post`, `stream_api_get`, `stream_api_post`) previously omitted a `timeout` argument, defaulting to `None` (blocking indefinitely). This could cause the caller to hang if the TCP connection stalled or the server accepted the connection but never responded.

## Fix

Add a configurable `timeout` parameter to `Client.__init__` (default 60.0s) and pass it down to all `requests.Session.get` and `post` calls.

Closes #212