### PR TITLE
fix: reject deleting the API Deleted Items directory before renaming it

### DIFF
--- a/src/labapi/tree/mixins.py
+++ b/src/labapi/tree/mixins.py
@@ -368,6 +368,12 @@ class AbstractTreeNode(AbstractBaseTreeNode):
         """
         api_deleted_items = self.root.dir("API Deleted Items")
 
+        if api_deleted_items is self:
+            raise ValueError(
+                "Cannot delete the 'API Deleted Items' directory through the API. "
+                "Delete it from the LabArchives web interface instead."
+            )
+
         self.name = (
             f"{self.name} - Deleted at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
         )

--- a/tests/tree/test_mixins.py
+++ b/tests/tree/test_mixins.py
@@ -285,6 +285,21 @@ class TestTreeMixinsIntegration:
         _ = client.pop_api_call()  # update_node for name
         _ = client.pop_api_call()  # update_node for move
 
+    def test_delete_api_deleted_items_rejected_before_rename(
+        self, client, notebook_tree: Notebook
+    ):
+        """Deleting the 'API Deleted Items' directory is rejected before any mutation."""
+        client.api_response = client.tree_node_response("deleted-dir")
+        trash = notebook_tree.dir("API Deleted Items")
+        client.clear_api_calls()
+        original_name = trash.name
+
+        with pytest.raises(ValueError, match="web interface"):
+            trash.delete()
+
+        assert trash.name == original_name
+        assert client.api_calls == ()
+
     def test_contains(self, notebook_tree: Notebook):
         """Test __contains__ handles strings and indexed slices properly."""
         assert "Test Folder A" in notebook_tree


### PR DESCRIPTION
## Summary

Calling `delete()` on the root-level **API Deleted Items** trash directory renamed it (a remote `update_node` call + local mutation) and *then* failed, leaving the directory in a broken, renamed state.

`AbstractTreeNode.delete()` resolves `self.root.dir("API Deleted Items")` as the move destination, sets `self.name = "... - Deleted at ..."` (which fires `update_node` and mutates local state), then calls `move_to()`. When the node being deleted **is** the trash directory, `move_to()` raises `ValueError("Cannot move a node to itself")` — but only *after* the rename already happened.

Of `move_to`'s three preconditions, only self-into-self is reachable from `delete()`: the destination is always in `self.root` (so the cross-notebook check never fires), and the only ancestor of the root-level trash dir is the notebook root, which has no `delete()`.

## Fix

Guard for `api_deleted_items is self` in `delete()` **before** the rename, raising a clear error that points the user to the LabArchives web interface (the API cannot delete its own trash directory). Normal deletes are unaffected — the guard only trips when the resolved trash dir is the node being deleted.

## Tests

- `test_delete_api_deleted_items_rejected_before_rename` — deleting the trash dir raises `ValueError` with no `update_node`/rename call and the name left unchanged (`client.api_calls == ()`).
- Existing `test_delete` still verifies the normal delete path.
- Full unit suite: 354 passed, 1 skipped. ruff + Pyright clean.

Fixes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)