### PR TITLE
fix: rewind attachment uploads via Attachment's defensive seekable check

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -187,8 +187,8 @@ class Entries(Sequence["Entry[Any]"]):
                     f"{type(data).__name__}"
                 )
 
-            if data._backing.seekable():  # pyright: ignore[reportPrivateUsage]
-                data._backing.seek(0)  # pyright: ignore[reportPrivateUsage]
+            if data.seekable():
+                data.seek(0)
 
             upload_kwargs = {
                 "filename": data.filename,

--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -124,8 +124,8 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         # NOTE: this implicitly invalidates all previous Attachments
         # NOTE: if every time content is called we give a new copy anyways that's fine
         #       (see get_attachment())
-        if value._backing.seekable():  # pyright: ignore[reportPrivateUsage]
-            value._backing.seek(0)  # pyright: ignore[reportPrivateUsage]
+        if value.seekable():
+            value.seek(0)
 
         self._user.api_post(
             "entries/update_attachment",

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -138,6 +138,32 @@ class TestAttachmentEntryIntegration:
         assert backing.tell() == 0
         _ = client.pop_api_call()
 
+    def test_attachment_entry_content_setter_stream_without_callable_seekable(
+        self, client, user: User
+    ):
+        """Update must not fail on streams whose seekable attribute is not callable."""
+        entry = AttachmentEntry("eid_att", "Old caption", user)
+
+        stream_cls = type("Stream", (BytesIO,), {"seekable": None})
+        backing = stream_cls(b"New file content")
+        new_attachment = Attachment(
+            backing=backing,
+            mime_type="text/plain",
+            filename="new_file.txt",
+            caption="New caption",
+        )
+        new_attachment.read(4)
+
+        client.api_response = client.xml(
+            "entry",
+            client.xml("success", True),
+        )
+
+        entry.content = new_attachment
+
+        assert backing.tell() == 0
+        _ = client.pop_api_call()
+
     def test_attachment_entry_get_attachment_caching(self, client, user: User):
         """Test AttachmentEntry.get_attachment reuses download cache without sharing handles."""
         entry = AttachmentEntry("eid_att", "Caption", user)

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -321,6 +321,32 @@ class TestEntriesIntegration:
         assert backing.tell() == 0
         _ = client.pop_api_call()
 
+    def test_entries_create_attachment_stream_without_callable_seekable(
+        self, client, user: User, mock_page
+    ):
+        """Create must not fail on streams whose seekable attribute is not callable."""
+        entries = Entries([], user, mock_page)
+
+        client.api_response = client.entries_response(
+            client.entry_xml("noseek_attachment_eid")
+        )
+
+        stream_cls = type("Stream", (BytesIO,), {"seekable": None})
+        backing = stream_cls(b"File content")
+        attachment = Attachment(
+            backing=backing,
+            mime_type="text/plain",
+            filename="test.txt",
+            caption="Test file",
+        )
+        attachment.read(4)
+
+        entry = entries.create(AttachmentEntry, attachment)
+
+        assert isinstance(entry, AttachmentEntry)
+        assert backing.tell() == 0
+        _ = client.pop_api_call()
+
     def test_entries_create_json_entry(self, client, user: User, mock_page):
         """Test Entries.create_json_entry creates both attachment and text entry."""
         entries = Entries([], user, mock_page)


### PR DESCRIPTION
## Summary

An `Attachment` could be constructed successfully and then fail before the API call. `Entries.create` and the `AttachmentEntry.content` setter called the **raw backing stream's** `.seekable()`:

```python
if data._backing.seekable():   # TypeError if seekable is not callable
    data._backing.seek(0)
```

For a stream whose `seekable` attribute is not callable (e.g. `None`), this raises `TypeError: 'NoneType' object is not callable` — even though `Attachment.__init__` accepted the stream via its defensive `_is_seekable` probe (which falls back to `seek`/`tell` when `seekable` is missing/non-callable).

## Root cause

`Attachment` gained a public, defensive `seekable()` (built on `_is_seekable`) in commit `f9a744b` ("fix: handle attachment streams without seekable", 2026-04-20), but that fix updated only `Attachment`'s construction — the older create/update call sites (from `63c0d06`, 2026-04-01) were left calling the raw `_backing.seekable()`. This PR finishes that fix.

## Fix

Route both call sites through the `Attachment`'s own public methods:

```python
if data.seekable():   # Attachment.seekable() -> _is_seekable(_backing)
    data.seek(0)
```

`Attachment.seekable()` handles missing/non-callable `seekable` defensively, and `Attachment.seek()` proxies to the backing stream. The actual upload (`api_post(..., data._backing, ...)`) is unchanged.

## Tests

- `test_entries_create_attachment_stream_without_callable_seekable` (create path)
- `test_attachment_entry_content_setter_stream_without_callable_seekable` (update path)

Both build an `Attachment` over a `BytesIO` subclass with `seekable = None` and assert the upload succeeds and the stream is rewound. Full unit suite: 355 passed, 1 skipped. ruff + Pyright clean.

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)