### PR TITLE
fix: record per-entry failure in json_sync when attachment retrieval fails

### DIFF
--- a/examples/json_sync/json_sync.py
+++ b/examples/json_sync/json_sync.py
@@ -135,9 +135,16 @@ def download_json_files(
         if not isinstance(entry, AttachmentEntry):
             continue
 
-        # ``entry.content`` downloads a fresh Attachment object. Close it when
-        # finished so local file handles or temporary buffers are released.
-        attachment = entry.content
+        # ``entry.content`` downloads a fresh Attachment object. A failed
+        # retrieval is recorded per-entry so later entries still process.
+        try:
+            attachment = entry.content
+        except Exception as exc:
+            results.append(FileResult(entry.id, folder, False, str(exc)))
+            continue
+
+        # Close the attachment when finished so local file handles or temporary
+        # buffers are released.
         try:
             # Treat remote filenames as filenames, not paths. This keeps every
             # download inside ``folder`` even if a server-provided name includes

--- a/tests/examples/test_json_sync.py
+++ b/tests/examples/test_json_sync.py
@@ -173,6 +173,18 @@ def _make_attachment_entry(
     return entry
 
 
+def _make_failing_attachment_entry(entry_id: str) -> AttachmentEntry:
+    """Create an attachment entry whose content retrieval raises."""
+    entry = AttachmentEntry(entry_id, "caption", cast(User, object()))
+
+    def get_attachment(use_tempfile: bool = False) -> Attachment:
+        del use_tempfile
+        raise RuntimeError("content unavailable")
+
+    entry.get_attachment = get_attachment
+    return entry
+
+
 def test_cli_module_import_has_no_side_effects():
     """Test importing the CLI module does not run authentication."""
     parser = json_sync.build_parser()
@@ -297,6 +309,38 @@ def test_download_json_files_writes_json_attachments_inside_target_folder(tmp_pa
     assert results[0].success is True
     assert results[0].name == "results.json"
     assert results[0].path == tmp_path / "results.json"
+    assert json.loads((tmp_path / "results.json").read_text(encoding="utf-8")) == {
+        "score": 42
+    }
+
+
+def test_download_json_files_records_failure_and_continues(tmp_path):
+    """A failed attachment retrieval is recorded per-entry; later entries still process."""
+    failing_entry = _make_failing_attachment_entry("bad-entry")
+    good_entry = _make_attachment_entry(
+        "good-entry",
+        "results.json",
+        "application/json",
+        b'{"score": 42}',
+    )
+    entries = _RecordingEntries([failing_entry, good_entry])
+    page = _PageDouble(entries)
+    notebook = _RecordingContainer(traverse_result=_PageNode(page))
+    user = _UserDouble(notebook)
+
+    results = json_sync.download_json_files(
+        user,
+        notebook="My Notebook",
+        page="Results/Page",
+        folder=tmp_path,
+    )
+
+    assert len(results) == 2
+    assert results[0].name == "bad-entry"
+    assert results[0].success is False
+    assert results[0].error == "content unavailable"
+    assert results[1].name == "results.json"
+    assert results[1].success is True
     assert json.loads((tmp_path / "results.json").read_text(encoding="utf-8")) == {
         "score": 42
     }


### PR DESCRIPTION
## Summary

`download_json_files` (`examples/json_sync/json_sync.py`) is designed to return a per-file `FileResult` for each attachment, marking failures and continuing. But it read `entry.content` — which triggers the actual attachment download — **before** the `try` block that records per-file failures:

```python
attachment = entry.content   # outside the try
try:
    ...
    except Exception as exc:
        results.append(FileResult(..., False, str(exc)))
finally:
    attachment.close()
```

So if one attachment's retrieval raised, the exception escaped `download_json_files` entirely and every later entry was skipped.

## Fix

Move the content retrieval into its own guarded block that records a failed `FileResult` (`name=entry.id`, `path=folder`, since no filename is known yet) and `continue`s to the next entry. The rest of the loop body and its `try/finally` (which closes the attachment) are unchanged.

## Tests

- `test_download_json_files_records_failure_and_continues` — a page with a failing-`content` entry followed by a good JSON entry: the failing one yields a failed `FileResult`, and the good one still downloads.

Example test suite passes (8); full unit suite green; ruff + Pyright clean.

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)