### PR TITLE
fix: escape metadata and make success message ASCII-safe in model_logging

### DIFF
--- a/examples/model_logging/model_logger.py
+++ b/examples/model_logging/model_logger.py
@@ -122,7 +122,7 @@ class ModelLogger:
             )
             entries.create(AttachmentEntry, fig_attachment)
 
-        print("✓ Log complete!")
+        print("Log complete!")
 
 
 def main() -> None:

--- a/examples/model_logging/model_logger.py
+++ b/examples/model_logging/model_logger.py
@@ -4,6 +4,7 @@
 import sys
 from collections.abc import Sequence
 from datetime import datetime
+from html import escape
 from typing import Any
 
 from labapi import (
@@ -76,7 +77,9 @@ class ModelLogger:
         )
 
         # 1. Log Commit Hash
-        entries.create(TextEntry, f"<p><strong>Git Commit:</strong> {commit}</p>")
+        entries.create(
+            TextEntry, f"<p><strong>Git Commit:</strong> {escape(commit)}</p>"
+        )
 
         # 2. Log Tags
         # Flatten tags if they are mixed str and list[str]
@@ -89,7 +92,7 @@ class ModelLogger:
 
         tags_html = "".join(
             [
-                f'<span style="background: #eee; padding: 2px 5px; margin: 2px; border-radius: 3px;">{t}</span>'
+                f'<span style="background: #eee; padding: 2px 5px; margin: 2px; border-radius: 3px;">{escape(t)}</span>'
                 for t in flat_tags
             ]
         )

--- a/tests/examples/test_model_logging.py
+++ b/tests/examples/test_model_logging.py
@@ -107,3 +107,18 @@ def test_log_escapes_commit_and_tags():
     assert "&lt;b&gt;x&lt;/b&gt;" in commit_html
     assert "<img" not in tags_html
     assert "&lt;img" in tags_html
+
+
+def test_log_success_message_is_ascii_safe(capsys):
+    """log() output must be printable on a non-UTF-8 (e.g. cp1252) console."""
+    entries = _EntriesDouble()
+    user = _UserDouble(_DirDouble(_PageDouble(entries)))
+    logger = model_logger.ModelLogger("My Research", cast(User, user))
+
+    logger.log(tags=[], metrics={}, results=b"", figures=[], commit="abc123")
+
+    out = capsys.readouterr().out
+    assert "Log complete!" in out
+    # Would raise UnicodeEncodeError if any character (e.g. a checkmark) is not
+    # encodable in the default Windows console encoding.
+    out.encode("cp1252")

--- a/tests/examples/test_model_logging.py
+++ b/tests/examples/test_model_logging.py
@@ -1,0 +1,109 @@
+"""Tests for the model_logging example script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+from labapi import NotebookPage, TextEntry, User
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[2] / "examples" / "model_logging"
+
+
+def _load_example_module(module_name: str, filename: str):
+    """Load an example module from the model_logging example directory."""
+    module_path = EXAMPLE_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+model_logger = _load_example_module("model_logger", "model_logger.py")
+
+
+class _EntriesDouble:
+    """Capture entry creation calls without hitting the API."""
+
+    def __init__(self) -> None:
+        """Initialize capture buffers."""
+        self.text_html: list[str] = []
+        self.json_calls: list[Any] = []
+        self.attachments: list[Any] = []
+
+    def create(self, cls: type, data: Any, **_kwargs: Any) -> object:
+        """Record a created entry, splitting text HTML from attachments."""
+        if cls is TextEntry:
+            self.text_html.append(cast(str, data))
+        else:
+            self.attachments.append(data)
+        return object()
+
+    def create_json_entry(self, metrics: Any, **_kwargs: Any) -> tuple[object, object]:
+        """Record a JSON entry creation."""
+        self.json_calls.append(metrics)
+        return object(), object()
+
+
+class _PageDouble:
+    """Minimal page double exposing an entries collection."""
+
+    def __init__(self, entries: _EntriesDouble) -> None:
+        """Initialize the page double."""
+        self.entries = entries
+
+
+class _DirDouble:
+    """Minimal container double that creates nested dirs and a page."""
+
+    def __init__(self, page: _PageDouble) -> None:
+        """Initialize the container double."""
+        self._page = page
+
+    def create(self, cls: type, _name: str, if_exists: Any = None) -> Any:
+        """Return the page for NotebookPage, otherwise another directory."""
+        del if_exists
+        if cls is NotebookPage:
+            return self._page
+        return self
+
+
+class _UserDouble:
+    """Minimal user double exposing notebooks and an email."""
+
+    def __init__(self, notebook: _DirDouble) -> None:
+        """Initialize the user double with one notebook."""
+        self.notebooks = {"My Research": notebook}
+        self.email = "researcher@example.com"
+
+
+def test_log_escapes_commit_and_tags():
+    """User-supplied commit and tags are HTML-escaped before embedding in HTML."""
+    entries = _EntriesDouble()
+    user = _UserDouble(_DirDouble(_PageDouble(entries)))
+    logger = model_logger.ModelLogger("My Research", cast(User, user))
+
+    logger.log(
+        tags=["<img src=x onerror=alert(1)>"],
+        metrics={},
+        results=b"",
+        figures=[],
+        commit="<b>x</b>",
+    )
+
+    commit_html, tags_html = entries.text_html[0], entries.text_html[1]
+
+    assert "<b>x</b>" not in commit_html
+    assert "&lt;b&gt;x&lt;/b&gt;" in commit_html
+    assert "<img" not in tags_html
+    assert "&lt;img" in tags_html


### PR DESCRIPTION
Two small correctness fixes in the `model_logging` example (`examples/model_logging/model_logger.py`), bundled because they touch the same file and share one new test module.

## #209 — HTML-escape commit and tags

`ModelLogger.log` interpolated user-supplied `commit` and tag values directly into `TextEntry` rich-text HTML:

```python
entries.create(TextEntry, f"<p><strong>Git Commit:</strong> {commit}</p>")
...
f'<span style="...">{t}</span>'   # per tag
```

Metadata containing HTML — e.g. a tag `"<img src=x onerror=alert(1)>"` or commit `"<b>x</b>"` — became **rendered markup** rather than literal text (a stored-injection footgun / corrupted metadata). Fixed by escaping both with `html.escape`, matching `create_json_entry` and the CSV example. (`metrics` already routes through `create_json_entry`; results/figures are binary attachments.)

## #210 — ASCII-safe success message

The final `print("✓ Log complete!")` used a Unicode checkmark (U+2713), which raises `UnicodeEncodeError` on the default non-UTF-8 Windows console (`cp1252`) — making a **successful** run appear to fail after remote content was already created. Dropped the checkmark: `print("Log complete!")`.

## Tests

New `tests/examples/test_model_logging.py`:
- `test_log_escapes_commit_and_tags` — malicious `commit`/tag through lightweight doubles; asserts captured `TextEntry` HTML contains escaped entities, not raw markup.
- `test_log_success_message_is_ascii_safe` — asserts `log()` output is `cp1252`-encodable (would fail on the old checkmark).

ruff + Pyright clean; full unit suite green.

Fixes #209
Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)