### PR TITLE
fix: type check optional dependencies

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,11 +9,11 @@ jobs:
     uses: ./.github/workflows/python_check.yml
     with:
       job_name: Pyright
-      command: uv run pyright
+      command: uv run --all-extras pyright
 
   ty:
     uses: ./.github/workflows/python_check.yml
     with:
       job_name: ty
-      command: uv run ty check
+      command: uv run --all-extras ty check
       append_python_version_arg: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,8 @@ addopts = "--cov=labapi --cov-report=term-missing"
 
 [tool.ty.analysis]
 replace-imports-with-any = [
-    "dotenv.**",
     "installed_browsers.**",
     "requests.**",
-    "selenium.**",
 ]
 
 [[tool.ty.overrides]]


### PR DESCRIPTION
## Summary

- Install all optional extras for the Pyright and ty GitHub Actions jobs.
- Let ty use the inline types supplied by `python-dotenv` and Selenium.
- Keep the `Any` replacement only for `installed_browsers` and `requests`, which have no usable inline types.

Closes #270.

## Validation

- `uv run --all-extras ty check`
- `uv run --all-extras pyright`
