### PR TITLE
docs: document notebook backup and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This changelog is written for package users and maintainers, so entries call
 out user-visible behavior, supported runtime changes, and release-engineering
 details that affect development workflows.
 
+## 1.2.0 - Unreleased
+
+### Added
+
+- `Notebook.backup()` downloads a notebook's native LabArchives backup archive
+  or JSON response, with options to omit attachment payloads.
+- `Notebook.export()` materializes a notebook as a local directory tree,
+  preserving empty directories and pages, entry ordering, attachments, and
+  per-page metadata. The optional `labapi[export]` extra reads native backup
+  archives; the default source falls back to the live API when needed.
+
 ## 1.1.1 - 2026-07-05
 
 ### Fixed

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -13,6 +13,7 @@ then move into the design notes if you are extending or contributing to
    :caption: Core Usage
 
    limitations
+   notebook_exports
    auth
    entries
    json_entries

--- a/docs/source/guide/notebook_exports.rst
+++ b/docs/source/guide/notebook_exports.rst
@@ -24,9 +24,10 @@ To omit attachment payloads from the archive, pass
 
    notebook.backup("metadata_only.7z", include_attachments=False)
 
-LabArchives only permits the notebook owner to request a native backup. When
-the API rejects the request, :class:`~labapi.exceptions.ApiError` reports the
-LabArchives error; error code ``4547`` means the owner must sign in first.
+LabArchives only permits the notebook owner's authenticated account to request
+a native backup. Error code ``4547`` means the currently authenticated account
+is not the owner; check ``Notebook Settings > Users`` in the LabArchives web UI
+and retry with the owner's credentials.
 
 Export a Directory Tree
 -----------------------

--- a/docs/source/guide/notebook_exports.rst
+++ b/docs/source/guide/notebook_exports.rst
@@ -69,9 +69,10 @@ install the ``export`` extra:
    pip install "labapi[export]"
 
 Use ``source="backup"`` to require the native archive, or ``source="walk"``
-to bypass it and read the live tree directly. A live walk may take longer for
-large notebooks because it downloads page content and attachment files through
-the API.
+to bypass it and read the live tree directly. A live walk can take a long time
+for large notebooks: LabArchives requires many API requests to enumerate and
+download page content and attachment files, so duration grows with notebook
+size.
 
 Related Pages
 -------------

--- a/docs/source/guide/notebook_exports.rst
+++ b/docs/source/guide/notebook_exports.rst
@@ -1,0 +1,79 @@
+.. _notebook_exports:
+
+Notebook Backups and Exports
+============================
+
+Use :meth:`~labapi.tree.notebook.Notebook.backup` to save the native
+LabArchives response, or :meth:`~labapi.tree.notebook.Notebook.export` to
+write a readable directory tree. The examples below assume you already have a
+``notebook`` object.
+
+Download a Native Backup
+------------------------
+
+Write LabArchives' native backup archive to a local file:
+
+.. code-block:: python
+
+   notebook.backup("my_notebook.7z")
+
+To omit attachment payloads from the archive, pass
+``include_attachments=False``:
+
+.. code-block:: python
+
+   notebook.backup("metadata_only.7z", include_attachments=False)
+
+LabArchives only permits the notebook owner to request a native backup. When
+the API rejects the request, :class:`~labapi.exceptions.ApiError` reports the
+LabArchives error; error code ``4547`` means the owner must sign in first.
+
+Export a Directory Tree
+-----------------------
+
+Export the notebook's top-level directories and pages to a local destination:
+
+.. code-block:: python
+
+   notebook.export("my_notebook")
+
+The destination contains numeric ordering prefixes, page content files, and a
+``.labarchives.json`` manifest for every page. The manifest records the page
+and entry IDs, output filenames, entry types, and available attachment details.
+For example:
+
+.. code-block:: text
+
+   my_notebook/
+   └── 1_Experiments/
+       └── 1_Run 1/
+           ├── 1_text.html
+           ├── 2_results.csv
+           └── .labarchives.json
+
+Empty directories are created, and empty pages still receive their manifest.
+If the destination already exists and is not empty,
+:meth:`~labapi.tree.notebook.Notebook.export` raises :class:`FileExistsError`.
+Pass ``overwrite=True`` to replace it.
+
+Choose an Export Source
+-----------------------
+
+``source="auto"`` is the default. It uses a native backup archive when
+available and otherwise walks the live API tree. To read native archives,
+install the ``export`` extra:
+
+.. code-block:: bash
+
+   pip install "labapi[export]"
+
+Use ``source="backup"`` to require the native archive, or ``source="walk"``
+to bypass it and read the live tree directly. A live walk may take longer for
+large notebooks because it downloads page content and attachment files through
+the API.
+
+Related Pages
+-------------
+
+- :ref:`installation` for optional dependency installation.
+- :ref:`limitations` for known API and entry-type constraints.

--- a/docs/source/quick_start/installation.rst
+++ b/docs/source/quick_start/installation.rst
@@ -34,6 +34,10 @@ Choose the install target that includes the helpers you need:
      - ``labapi[dotenv]``
      - You want :class:`~labapi.client.Client` to read a local ``.env`` file,
        but you do not need browser helpers.
+   * - Export native backups
+     - ``labapi[export]``
+     - You want :meth:`~labapi.tree.notebook.Notebook.export` to read native
+       LabArchives backup archives.
 
 .. tab-set::
 
@@ -44,6 +48,7 @@ Choose the install target that includes the helpers you need:
          uv add "labapi[dotenv,builtin-auth]"
          uv add labapi
          uv add "labapi[dotenv]"
+         uv add "labapi[export]"
 
    .. tab-item:: poetry
 
@@ -52,6 +57,7 @@ Choose the install target that includes the helpers you need:
          poetry add "labapi[dotenv,builtin-auth]"
          poetry add labapi
          poetry add "labapi[dotenv]"
+         poetry add "labapi[export]"
 
    .. tab-item:: pip
 
@@ -60,13 +66,14 @@ Choose the install target that includes the helpers you need:
          pip install "labapi[dotenv,builtin-auth]"
          pip install labapi
          pip install "labapi[dotenv]"
+         pip install "labapi[export]"
 
 .. _optional-deps:
 
 Optional Extras
 ---------------
 
-``labapi`` has two optional extras:
+``labapi`` has three optional extras:
 
 - ``dotenv`` lets :class:`~labapi.client.Client` read ``API_URL``,
   ``ACCESS_KEYID``, and ``ACCESS_PWD`` from a local ``.env`` file.
@@ -74,6 +81,9 @@ Optional Extras
   :meth:`~labapi.client.Client.default_authenticate` auto-detect and open a
   local browser. Without it, you can still use terminal/manual auth or your own
   callback flow.
+- ``export`` installs ``py7zr`` so
+  :meth:`~labapi.tree.notebook.Notebook.export` can read native LabArchives
+  backup archives. Live ``source="walk"`` exports do not need it.
 
 Configuration
 -------------

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -156,8 +156,9 @@ class Notebook(AbstractTreeContainer):
             (the API ``json`` option).
         :returns: The :class:`~pathlib.Path` the archive was written to.
         :raises ApiError: If LabArchives rejects the request. Error code
-            ``4547`` means the notebook owner must sign in before this action
-            can succeed.
+            ``4547`` means the currently authenticated account is not the
+            notebook owner. Check the owner in the LabArchives web UI, then
+            retry with that owner's credentials.
         """
         params: dict[str, str] = {}
         if as_json:


### PR DESCRIPTION
## Summary

- Document `Notebook.backup()` and `Notebook.export()` in a new user-guide page.
- Describe native versus live export sources, output layout, empty content, and owner-only backups.
- Add the `export` optional dependency to installation guidance and record the feature in the 1.2.0 changelog.

## Validation

- `git diff --check`
- Commit hook: Pyright
- `uv run sphinx-build -W -b html docs/source <tempdir>` parsed the updated docs without page or link warnings, but could not fetch external intersphinx inventories because the local network certificate chain is untrusted.
