### PR TITLE
feat: return notebook export results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ details that affect development workflows.
   per-page metadata. The optional `labapi[export]` extra reads native backup
   archives; the default source falls back to the live API when needed.
 
+### Changed
+
+- `Notebook.export()` now returns a `NotebookExport` result; its `path`
+  property is the completed export directory.
+
 ## 1.1.1 - 2026-07-05
 
 ### Fixed

--- a/docs/source/guide/notebook_exports.rst
+++ b/docs/source/guide/notebook_exports.rst
@@ -36,7 +36,8 @@ Export the notebook's top-level directories and pages to a local destination:
 
 .. code-block:: python
 
-   notebook.export("my_notebook")
+   export = notebook.export("my_notebook")
+   destination = export.path
 
 The destination contains numeric ordering prefixes, page content files, and a
 ``.labarchives.json`` manifest for every page. The manifest records the page

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -28,6 +28,22 @@ if TYPE_CHECKING:
     from .collection import Notebooks
 
 
+class NotebookExport(PathLike[str]):
+    """The completed result of exporting a notebook."""
+
+    def __init__(self, path: Path):
+        """Initialize the export result with its destination path."""
+        self.path = path
+
+    def __fspath__(self) -> str:
+        """Return the export destination as a filesystem path."""
+        return str(self.path)
+
+    def __str__(self) -> str:
+        """Return the export destination as text."""
+        return str(self.path)
+
+
 class Notebook(AbstractTreeContainer):
     """Represents a LabArchives notebook, acting as the root of a tree structure.
 
@@ -95,7 +111,7 @@ class Notebook(AbstractTreeContainer):
         *,
         source: Literal["auto", "walk", "backup"] = "auto",
         overwrite: bool = False,
-    ) -> Path:
+    ) -> NotebookExport:
         """Export this notebook to a local directory tree.
 
         Reconstructs the notebook as a folder mirror under ``destination``:
@@ -113,7 +129,8 @@ class Notebook(AbstractTreeContainer):
             uses the backup archive when available and falls back to the walk.
         :param overwrite: When ``destination`` exists and is not empty, raise
             unless ``overwrite`` is ``True``.
-        :returns: The path of the export directory.
+        :returns: A completed :class:`NotebookExport`. Its ``path`` is the
+            export directory.
         """
         backup_error = None
         with TemporaryDirectory() as tmp:
@@ -125,10 +142,12 @@ class Notebook(AbstractTreeContainer):
                 except (ImportError, ApiError) as error:
                     backup_error = error
                 else:
-                    return _write_tree(tree, destination, overwrite)
+                    return NotebookExport(_write_tree(tree, destination, overwrite))
 
             if source != "backup":
-                return _write_tree(_walk_tree(self, tmp_path), destination, overwrite)
+                return NotebookExport(
+                    _write_tree(_walk_tree(self, tmp_path), destination, overwrite)
+                )
 
         raise RuntimeError(
             f"Could not export notebook with source={source!r}"

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -28,20 +28,17 @@ if TYPE_CHECKING:
     from .collection import Notebooks
 
 
-class NotebookExport(PathLike[str]):
+class NotebookExport:
     """The completed result of exporting a notebook."""
 
     def __init__(self, path: Path):
         """Initialize the export result with its destination path."""
-        self.path = path
+        self._path = path
 
-    def __fspath__(self) -> str:
-        """Return the export destination as a filesystem path."""
-        return str(self.path)
-
-    def __str__(self) -> str:
-        """Return the export destination as text."""
-        return str(self.path)
+    @property
+    def path(self) -> Path:
+        """Return the export destination."""
+        return self._path
 
 
 class Notebook(AbstractTreeContainer):

--- a/tests/tree/test_export.py
+++ b/tests/tree/test_export.py
@@ -255,7 +255,7 @@ def test_auto_falls_back_to_walk(monkeypatch, notebook: LA.Notebook, tmp_path, e
 
 
 def test_backup_export_returns_result(monkeypatch, notebook: LA.Notebook, tmp_path):
-    """Backup exports return a completed path-like result."""
+    """Backup exports return a completed result."""
     monkeypatch.setattr(notebook_module, "_backup_tree", Mock(return_value={}))
 
     export = notebook.export(tmp_path / "export", source="backup")

--- a/tests/tree/test_export.py
+++ b/tests/tree/test_export.py
@@ -248,7 +248,21 @@ def test_auto_falls_back_to_walk(monkeypatch, notebook: LA.Notebook, tmp_path, e
     monkeypatch.setattr(notebook_module, "_backup_tree", Mock(side_effect=error))
     monkeypatch.setattr(notebook_module, "_walk_tree", Mock(return_value={}))
 
-    assert notebook.export(tmp_path / "export") == tmp_path / "export"
+    export = notebook.export(tmp_path / "export")
+
+    assert export.path == tmp_path / "export"
+    assert Path(export) == tmp_path / "export"
+    assert str(export) == str(tmp_path / "export")
+
+
+def test_backup_export_returns_result(monkeypatch, notebook: LA.Notebook, tmp_path):
+    """Backup exports return a completed path-like result."""
+    monkeypatch.setattr(notebook_module, "_backup_tree", Mock(return_value={}))
+
+    export = notebook.export(tmp_path / "export", source="backup")
+
+    assert isinstance(export, notebook_module.NotebookExport)
+    assert export.path == tmp_path / "export"
 
 
 def test_backup_source_chains_the_backup_error(

--- a/tests/tree/test_export.py
+++ b/tests/tree/test_export.py
@@ -251,8 +251,7 @@ def test_auto_falls_back_to_walk(monkeypatch, notebook: LA.Notebook, tmp_path, e
     export = notebook.export(tmp_path / "export")
 
     assert export.path == tmp_path / "export"
-    assert Path(export) == tmp_path / "export"
-    assert str(export) == str(tmp_path / "export")
+    assert isinstance(export.path, Path)
 
 
 def test_backup_export_returns_result(monkeypatch, notebook: LA.Notebook, tmp_path):


### PR DESCRIPTION
## Summary

- Return an opaque `NotebookExport` result from `Notebook.export()`.
- Expose the completed destination as `result.path`.
- Document result usage in the notebook-export guide and record the return contract in the 1.2.0 changelog.

## Why

`Notebook.export()` is still unreleased in 1.2.0. Establishing its result type now lets a later streaming implementation add status, waiting, and progress events without changing the method's return type.

This replaces #273, which was accidentally based on the already-merged documentation branch rather than `main`.

## Validation

- `uv run pytest -q tests/tree/test_export.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run ty check`
