### PR TITLE
Keep only current release candidate docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
 
+      - name: Keep only the current release candidate docs
+        run: |
+          git tag --list 'v*rc*' |
+            grep -vxF "$GITHUB_REF_NAME" |
+            xargs --no-run-if-empty git tag --delete
+
       - name: Build versioned Sphinx docs
         run: uv run sphinx-multiversion docs/source docs/_build/html
 
@@ -57,7 +63,7 @@ jobs:
           fi
 
           touch docs/_build/html/.nojekyll
-          # Stable alias so deep links (e.g. from the README) survive releases.
+          # Release candidates are versioned only; the default always stays final.
           cp -r "docs/_build/html/${latest}" docs/_build/html/latest
           cat > docs/_build/html/index.html <<EOF
           <!doctype html>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ details that affect development workflows.
 
 - Client base URLs now discard fragments and warn when they contain query
   parameters that cannot be preserved in API requests.
+- Versioned documentation shows only the newest release candidate and keeps
+  the root and `latest/` aliases on the newest final release.
 
 ### Fixed
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ from importlib.metadata import metadata as _metadata
 from importlib.metadata import version as _version
 from pathlib import Path
 
-_VERSION_TAG = r"^v(\d+\.\d+\.\d+)$"
+_VERSION_TAG = r"^v(\d+\.\d+\.\d+(?:rc\d+)?)$"
 
 sys.path.insert(0, str((Path(__file__).resolve().parents[2] / "src").resolve()))
 


### PR DESCRIPTION
## Summary

- build documentation for final tags and the current release-candidate tag
- keep the root and `latest/` aliases on the newest final release
- document the behavior in the 1.2.0 changelog

## Why

Release-candidate documentation should be available while that candidate is current, but it must neither remain after a subsequent release nor become the default documentation.

## Impact

The Pages workflow deletes superseded release-candidate refs only in its temporary checkout. It does not alter remote tags or PyPI publishing.

## Validation

- isolated Git test covering RC1 -> RC2 -> final-release tag selection
- Ruff lint and format checks
- Pyright
