### PR TITLE
Prepare 1.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This changelog is written for package users and maintainers, so entries call
 out user-visible behavior, supported runtime changes, and release-engineering
 details that affect development workflows.
 
-## 1.2.0 - Unreleased
+## 1.2.0 - 2026-07-23
 
 ### Added
 
@@ -24,6 +24,7 @@ details that affect development workflows.
 
 - Client base URLs now discard fragments and warn when they contain query
   parameters that cannot be preserved in API requests.
+- Updated the locked indirect Pillow dependency from 12.2.0 to 12.3.0.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- mark the 1.2.0 changelog as released on 2026-07-23
- record the merged Dependabot update of the locked indirect Pillow dependency

## Impact

This is documentation-only release preparation; package code and dependencies are unchanged by this PR.

## Validation

- inspected the Dependabot merge commit
- `git diff --check`
- pre-commit Pyright
