### PR TITLE
Preserve spaces around inline CSV markup

### DIFF
--- a/examples/csv_table/csv_table.py
+++ b/examples/csv_table/csv_table.py
@@ -345,7 +345,7 @@ def _find_tags(node: Tag, names: _TagNames) -> tuple[Tag, ...]:
 
 def _cell_texts(cells: Sequence[Tag]) -> _CsvRow:
     """Return stripped visible text from table cell tags."""
-    return tuple(cell.get_text(strip=True) for cell in cells)
+    return tuple(cell.get_text(" ", strip=True) for cell in cells)
 
 
 def main() -> None:

--- a/tests/examples/test_csv_table.py
+++ b/tests/examples/test_csv_table.py
@@ -215,6 +215,15 @@ def test_download_table_can_use_explicit_entry_index(tmp_path: Path):
     assert output_file.read_text(encoding="utf-8") == "first,1\n"
 
 
+def test_parse_html_table_separates_inline_markup_text():
+    """Test inline markup does not concatenate adjacent cell text."""
+    table = csv_table._parse_html_table(
+        "<table><tr><td>alpha <strong>beta</strong></td></tr></table>"
+    )
+
+    assert table.rows == (("alpha beta",),)
+
+
 def test_download_table_raises_on_directory_path(
     capsys: pytest.CaptureFixture[str],
 ):


### PR DESCRIPTION
Closes #206.

## Summary

- preserve a separator between adjacent visible text nodes in HTML table cells
- cover inline markup in CSV-table parsing

## Why

BeautifulSoup concatenated adjacent text around inline markup when called without a separator, silently changing exported cell text.

## Validation

- `pytest tests/examples/test_csv_table.py`
- Ruff lint and format checks
- Pyright
