### PR TITLE
Fall back after configured browser probe errors

### DIFF
--- a/src/labapi/util/browser.py
+++ b/src/labapi/util/browser.py
@@ -73,8 +73,17 @@ def _find_chosen_browser(browser: _ChoosableBrowser | None) -> _ChoosableBrowser
         )
         return "terminal"
 
-    if installed_browsers.do_i_have_installed(browser):
-        return browser
+    try:
+        if installed_browsers.do_i_have_installed(browser):
+            return browser
+    except OSError as exc:
+        warnings.warn(
+            f"Configured browser probe failed: {exc}. "
+            "Falling back to automatic browser detection.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
 
     # Fall back to a linear search: installed-browsers may register a browser
     # under a key that differs from our canonical name (e.g. Edge as "msedge"),

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -197,6 +197,20 @@ def test_browser_detection_warns_and_autodetects_when_preferred_browser_missing(
         assert browser_module.detect_default_browser() == "firefox"
 
 
+def test_configured_browser_probe_error_falls_back_to_autodetection(
+    browser_module, mock_installed_browsers, monkeypatch
+):
+    """Test configured browser probe errors fall back to autodetection."""
+    monkeypatch.setenv("LA_AUTH_BROWSER", "chrome")
+    mock_installed_browsers.do_i_have_installed.side_effect = PermissionError(
+        "access denied"
+    )
+    mock_installed_browsers.what_is_the_default_browser.return_value = "Mozilla Firefox"
+
+    with pytest.warns(RuntimeWarning, match="Configured browser probe failed"):
+        assert browser_module.detect_default_browser() == "firefox"
+
+
 def test_browser_detection_runtime_failure_warns(
     browser_module, mock_installed_browsers, monkeypatch
 ):


### PR DESCRIPTION
Closes #200.

## Summary

- catch `OSError` from an explicitly configured browser probe
- continue through existing automatic browser detection or terminal fallback
- cover a Windows-style registry permission failure

## Why

`installed_browsers` can raise an `OSError` while reading the Windows registry. The explicit configuration path previously let that error abort authentication.

## Validation

- `pytest tests/test_browser.py`
- Ruff lint and format checks
- Pyright
