### PR TITLE
Allow optional fields in entry parsing

### DIFF
--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -88,24 +88,31 @@ class NotebookPage(AbstractTreeNode):
             )
 
             for entry in entries_tree.iterfind(".//entry"):
-                entry_data = extract_etree(
+                entry_fields = extract_etree(
                     entry,
                     {
                         "eid": str,
                         "part-type": str,
-                        "attach-file-name": str,
-                        "attach-content-type": str,
-                        "entry-data": str,
                     },
                 )
+                entry_content = extract_etree(
+                    entry,
+                    {"entry-data": str, "caption": str},
+                    raise_missing=False,
+                )
 
-                part_type = entry_data["part-type"]
+                part_type = entry_fields["part-type"]
+                data = (
+                    entry_content.get("entry-data")
+                    or entry_content.get("caption")
+                    or ""
+                )
 
                 # Cast extracted string values to ensure type checker knows they're not None
                 entry_obj = Entry.from_part_type(
                     part_type,
-                    cast(str, entry_data["eid"]),
-                    cast(str, entry_data["entry-data"]),
+                    cast(str, entry_fields["eid"]),
+                    data,
                     self._user,
                 )
 
@@ -113,14 +120,14 @@ class NotebookPage(AbstractTreeNode):
                     pass
                 elif isinstance(entry_obj, UnimplementedEntry):
                     warnings.warn(
-                        f"Entry type '{part_type}' (ID: {entry_data['eid']}) is recognized but not "
+                        f"Entry type '{part_type}' (ID: {entry_fields['eid']}) is recognized but not "
                         f"implemented in labapi. Wrapping as UnimplementedEntry.",
                         UserWarning,
                         stacklevel=2,
                     )
                 elif isinstance(entry_obj, UnknownEntry):
                     warnings.warn(
-                        f"Unknown entry type '{part_type}' (ID: {entry_data['eid']}) encountered. "
+                        f"Unknown entry type '{part_type}' (ID: {entry_fields['eid']}) encountered. "
                         f"Wrapping as UnknownEntry.",
                         RuntimeWarning,
                         stacklevel=2,

--- a/src/labapi/util/extract.py
+++ b/src/labapi/util/extract.py
@@ -75,7 +75,12 @@ def to_bool(s: str) -> bool:
             raise ValueError(f"Cannot convert '{s}' to bool")
 
 
-def extract_etree(_etree: Element, schema: EtreeExtractorDict) -> dict[str, Any]:
+def extract_etree(
+    _etree: Element,
+    schema: EtreeExtractorDict,
+    *,
+    raise_missing: bool = True,
+) -> dict[str, Any]:
     """Extract data from an ``lxml.etree.Element`` using a format dictionary.
 
     This function navigates the XML tree using paths defined in the `schema` dictionary
@@ -85,9 +90,13 @@ def extract_etree(_etree: Element, schema: EtreeExtractorDict) -> dict[str, Any]
     :param schema: A dictionary defining the structure and extraction logic.
                    Keys are XML element tags (or paths), and values are either
                    nested `EtreeExtractorDict` or callable functions to process the text.
+    :param raise_missing: Whether to raise :class:`ExtractionError` when a
+                           requested element is missing. When false, missing
+                           values are omitted from the result.
     :returns: A dictionary containing the extracted and processed data.
-    :raises ExtractionError: If an element specified in the format is not found in the etree,
-                             or if a callable extractor fails to process a value.
+    :raises ExtractionError: If a requested element is missing while
+                             ``raise_missing`` is true, or if a callable
+                             extractor fails to process a value.
     """
     flat = _flatten_dict(schema)
 
@@ -98,12 +107,12 @@ def extract_etree(_etree: Element, schema: EtreeExtractorDict) -> dict[str, Any]
         message_path = f"./{key}"
         value = _etree.findtext(f"./{key}")
 
-        if (
-            value is None
-        ):  # XXX should we collate errors and return at end with the dict or?
-            raise ExtractionError(
-                f"Could not find value for './{key}' while parsing element at {etree_path}"
-            )
+        if value is None:
+            if raise_missing:
+                raise ExtractionError(
+                    f"Could not find value for './{key}' while parsing element at {etree_path}"
+                )
+            continue
 
         leaf = key.split("/")[-1]
 

--- a/tests/tree/test_page.py
+++ b/tests/tree/test_page.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 from labapi import Index, Notebook, NotebookPage
-from labapi.entry import Attachment, Entries, UnknownEntry, WidgetEntry
+from labapi.entry import Attachment, AttachmentEntry, Entries, UnknownEntry, WidgetEntry
 from labapi.user import User
 
 
@@ -309,6 +309,60 @@ class TestNotebookPageIntegration:
         assert isinstance(entries[0], UnknownEntry)
         assert entries[0].content_type == "future entry"
         assert entries[0].content == "future payload"
+        _ = client.pop_api_call()
+        client.clear_api_calls()
+
+    def test_page_entries_wrap_unknown_type_without_optional_fields(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test page loading preserves unknown entries without optional fields."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_api_calls()
+        client.api_response = client.entries_response(
+            client.xml(
+                "entry",
+                client.xml("eid", "entry_unknown_new"),
+                client.xml("part-type", "future entry"),
+            ),
+            include_response=False,
+        )
+
+        with pytest.warns(RuntimeWarning, match="Wrapping as UnknownEntry"):
+            entries = page.entries
+
+        assert len(entries) == 1
+        assert isinstance(entries[0], UnknownEntry)
+        assert entries[0].content == ""
+        _ = client.pop_api_call()
+        client.clear_api_calls()
+
+    def test_page_entries_use_caption_when_attachment_data_is_nil(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test attachment captions replace nil entry data."""
+        page = notebook_tree[Index.Id : "page-1"]
+
+        assert isinstance(page, NotebookPage)
+        client.clear_api_calls()
+        client.api_response = client.entries_response(
+            client.xml(
+                "entry",
+                client.xml("eid", "attachment-1"),
+                client.xml("part-type", "Attachment"),
+                client.xml("entry-data", nil="true"),
+                client.xml("caption", "Data file"),
+            ),
+            include_response=False,
+        )
+
+        entries = page.entries
+
+        assert len(entries) == 1
+        attachment_entry = entries[0]
+        assert isinstance(attachment_entry, AttachmentEntry)
+        assert attachment_entry.caption == "Data file"
         _ = client.pop_api_call()
         client.clear_api_calls()
 

--- a/tests/util/test_extract.py
+++ b/tests/util/test_extract.py
@@ -203,6 +203,19 @@ def test_extract_etree_missing_element_raises():
         extract_etree(element, format_dict)
 
 
+def test_extract_etree_can_skip_missing_elements():
+    """Test optional extraction omits missing elements."""
+    element = etree.fromstring(b"<root><name>Test</name><empty /></root>")
+
+    result = extract_etree(
+        element,
+        {"name": str, "empty": str, "missing": str},
+        raise_missing=False,
+    )
+
+    assert result == {"name": "Test", "empty": ""}
+
+
 def test_extract_etree_mapper_fails_raises():
     """Test extract_etree raises ValueError when mapper fails."""
     xml = """<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Closes #196.

## Summary

- allow `extract_etree()` callers to omit missing schema fields with `raise_missing=False`
- parse a page entry's required identity separately from optional content
- use an attachment caption when its entry-data is nil

## Why

Page parsing required fields that future or attachment-style entry responses may omit, preventing the existing unknown-entry fallback from running.

## Validation

- `pytest tests/util/test_extract.py tests/tree/test_page.py`
- Ruff lint and format checks
- Pyright
