### PR TITLE
Add authenticated notebook and page Web UI URLs

### DIFF
--- a/docs/source/guide/paths.rst
+++ b/docs/source/guide/paths.rst
@@ -12,8 +12,9 @@ avoid long chains of indexing when structures are deeply nested.
 Web URLs
 --------
 
-Notebooks and pages expose their authenticated LabArchives Web UI URLs through
-their ``url`` properties. These are direct Web UI links, not Share URLs.
+Notebook and page ``url`` properties return direct LabArchives Web UI links.
+They are not Share URLs: only signed-in users authorized to access the target
+can view it.
 For a custom API host, pass its Web UI base URL explicitly to
 ``Client(..., web_url="https://notebooks.example.com")``.
 

--- a/docs/source/guide/paths.rst
+++ b/docs/source/guide/paths.rst
@@ -9,6 +9,17 @@ avoid long chains of indexing when structures are deeply nested.
 .. seealso::
    :ref:`index_access` for duplicate-name and first-match lookup behavior.
 
+Web URLs
+--------
+
+Notebooks and pages expose their authenticated LabArchives Web UI URLs through
+their ``url`` properties. These are direct Web UI links, not Share URLs.
+
+.. code-block:: python
+
+    print(notebook.url)
+    print(page.url)
+
 .. code-block:: python
 
     from labapi import TraversalError

--- a/docs/source/guide/paths.rst
+++ b/docs/source/guide/paths.rst
@@ -14,6 +14,8 @@ Web URLs
 
 Notebooks and pages expose their authenticated LabArchives Web UI URLs through
 their ``url`` properties. These are direct Web UI links, not Share URLs.
+For a custom API host, pass its Web UI base URL explicitly to
+``Client(..., web_url="https://notebooks.example.com")``.
 
 .. code-block:: python
 

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -48,6 +48,38 @@ _DEFAULT_AUTH_CALLBACK_PORT = 8089
 
 _DEFAULT_AUTH_CALLBACK_TIMEOUT = 300.0
 
+_WEB_UI_HOSTS = {
+    "api.labarchives.com": "mynotebook.labarchives.com",
+    "api.labarchives-gov.com": "mynotebook.labarchives-gov.com",
+    "auapi.labarchives.com": "au-mynotebook.labarchives.com",
+    "caapi.labarchives.com": "ca-mynotebook.labarchives.com",
+    "euapi.labarchives.com": "eu-mynotebook.labarchives.com",
+    "ukapi.labarchives.com": "uk-mynotebook.labarchives.com",
+}
+
+
+def _normalize_web_url(web_url: str) -> str:
+    """Validate and normalize an explicitly configured Web UI base URL."""
+    parsed_web_url = urlsplit(web_url)
+    if (
+        parsed_web_url.scheme not in {"http", "https"}
+        or not parsed_web_url.netloc
+        or parsed_web_url.query
+        or parsed_web_url.fragment
+    ):
+        raise ValueError(
+            "Invalid web_url: expected a full HTTP(S) URL without a query or fragment."
+        )
+    return urlunsplit(
+        (
+            parsed_web_url.scheme,
+            parsed_web_url.netloc,
+            parsed_web_url.path.rstrip("/"),
+            "",
+            "",
+        )
+    )
+
 
 context = ssl.create_default_context()
 
@@ -267,6 +299,7 @@ class Client:
         akid: str | None = None,
         akpass: bytes | str | None = None,
         *,
+        web_url: str | None = None,
         strict_cert: bool = True,
         timeout: float | tuple[float, float] | None = 60.0,
     ):
@@ -279,12 +312,14 @@ class Client:
         - ``ACCESS_KEYID``: The Access Key ID.
         - ``ACCESS_PWD``: The Access Key Password.
 
-        :param base_url: The base URL of the LabArchives API (e.g., "https://mynotebook.labarchives.com").
+        :param base_url: The base URL of the LabArchives API (e.g., "https://api.labarchives.com").
                          If None, loaded from the ``API_URL`` environment variable.
         :param akid: The Access Key ID for API authentication.
                      If None, loaded from the ``ACCESS_KEYID`` environment variable.
         :param akpass: The Access Key Password for HMAC-SHA512 signing.
                        If None, loaded from the ``ACCESS_PWD`` environment variable.
+        :param web_url: The base URL of the LabArchives Web UI. If None, inferred
+                        from a supported API host when needed.
         :param strict_cert: Whether to use strict X.509 certificate verification.
                            If False, disables the VERIFY_X509_STRICT flag to allow connections
                            to servers with certificates that may not pass strict validation.
@@ -326,6 +361,7 @@ class Client:
             )
 
         self._base_url = normalized_base_url
+        self._web_url = _normalize_web_url(web_url) if web_url is not None else None
         self._akid = akid
         self._hmac = HMAC(
             bytes(akpass, "utf8") if isinstance(akpass, str) else akpass, SHA512()
@@ -339,7 +375,18 @@ class Client:
     @property
     def web_url(self) -> str:
         """Return the LabArchives Web UI base URL."""
-        return self._base_url.replace("api.", "mynotebook.")
+        if self._web_url is not None:
+            return self._web_url
+
+        parsed_base_url = urlsplit(self._base_url)
+        try:
+            web_host = _WEB_UI_HOSTS[parsed_base_url.hostname or ""]
+        except KeyError as error:
+            raise ValueError(
+                "Cannot infer a LabArchives Web UI URL from API base URL "
+                f"{self._base_url!r}; pass web_url explicitly."
+            ) from error
+        return urlunsplit((parsed_base_url.scheme, web_host, "", "", ""))
 
     def close(self) -> None:
         """Close the underlying requests session.

--- a/src/labapi/client.py
+++ b/src/labapi/client.py
@@ -336,6 +336,11 @@ class Client:
         if not strict_cert:
             self.session.mount("https://", _313HTTPAdapter())
 
+    @property
+    def web_url(self) -> str:
+        """Return the LabArchives Web UI base URL."""
+        return self._base_url.replace("api.", "mynotebook.")
+
     def close(self) -> None:
         """Close the underlying requests session.
 

--- a/src/labapi/tree/notebook.py
+++ b/src/labapi/tree/notebook.py
@@ -69,6 +69,11 @@ class Notebook(AbstractTreeContainer):
         """
         return self._id
 
+    @property
+    def url(self) -> str:
+        """Return this notebook's LabArchives Web UI URL."""
+        return f"{self.user.client.web_url}/{self.id}"
+
     @HasNameMixin.name.setter  # type: ignore[attr-defined]
     def name(self, value: str) -> None:
         """Set the notebook name.

--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -66,6 +66,11 @@ class NotebookPage(AbstractTreeNode):
         return super().id
 
     @property
+    def url(self) -> str:
+        """Return this page's LabArchives Web UI URL."""
+        return f"{self.user.client.web_url}/{self.root.id}/page/{self.id}"
+
+    @property
     def entries(self) -> Entries:
         """Return this page's entries, loading them from the API on first access.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1054,6 +1054,40 @@ class TestClientUnit:
         assert client._akid == "test_akid"  # pyright: ignore[reportPrivateUsage]
         assert client._base_url == "https://test.api/"  # pyright: ignore[reportPrivateUsage]
 
+    def test_client_web_url_override(self):
+        """Test Client accepts an explicit Web UI URL for custom API hosts."""
+        client = Client(
+            "https://api.example.com/api",
+            "test_akid",
+            "test_akpass",
+            web_url="https://notebooks.example.com/eln/",
+        )
+        assert client.web_url == "https://notebooks.example.com/eln"
+
+    def test_client_web_url_requires_override_for_unknown_api_host(self):
+        """Test Client rejects unknown API hosts when a Web UI URL is requested."""
+        client = Client("https://api.example.com", "test_akid", "test_akpass")
+        with pytest.raises(ValueError, match="pass web_url explicitly"):
+            _ = client.web_url
+
+    @pytest.mark.parametrize(
+        "web_url",
+        [
+            "not-a-url",
+            "https://notebooks.example.com/?preview=true",
+            "https://notebooks.example.com/#overview",
+        ],
+    )
+    def test_client_rejects_invalid_web_url(self, web_url):
+        """Test Client validates explicit Web UI base URLs."""
+        with pytest.raises(ValueError, match="Invalid web_url"):
+            Client(
+                "https://api.example.com",
+                "test_akid",
+                "test_akpass",
+                web_url=web_url,
+            )
+
     def test_client_initialization_warns_on_query_parameters(self):
         """Test Client warns when initialized with a base_url containing query parameters."""
         with pytest.warns(

--- a/tests/tree/test_notebook.py
+++ b/tests/tree/test_notebook.py
@@ -8,8 +8,10 @@ import pytest
 
 from labapi import (
     AttachmentEntry,
+    Client,
     HeaderEntry,
     Notebook,
+    NotebookPage,
     PlainTextEntry,
     TextEntry,
     UnknownEntry,
@@ -47,6 +49,24 @@ class TestNotebookUnit:
         assert notebook.name == "Test Notebook"
         assert notebook.is_default is True
         assert notebook.root is notebook
+
+    def test_notebook_and_page_urls(self):
+        """Test notebooks and pages build Web UI URLs from their IDs."""
+        with Client("https://api.labarchives-gov.com", "test", "test") as client:
+            user = User("test-user", "test@example.com", [], client)
+            notebook = Notebook(
+                NotebookInit("notebook-token", "Test Notebook", False),
+                user,
+                user.notebooks,
+            )
+            page = NotebookPage("page-1", "Test Page", notebook, notebook, user)
+
+            assert notebook.url == (
+                "https://mynotebook.labarchives-gov.com/notebook-token"
+            )
+            assert page.url == (
+                "https://mynotebook.labarchives-gov.com/notebook-token/page/page-1"
+            )
 
     def test_search_is_lazy(self):
         """Test Notebook.search does not call the API until a page is requested."""

--- a/tests/tree/test_notebook.py
+++ b/tests/tree/test_notebook.py
@@ -50,9 +50,51 @@ class TestNotebookUnit:
         assert notebook.is_default is True
         assert notebook.root is notebook
 
-    def test_notebook_and_page_urls(self):
+    @pytest.mark.parametrize(
+        ("base_url", "expected_web_url", "configured_web_url"),
+        [
+            (
+                "https://api.labarchives.com",
+                "https://mynotebook.labarchives.com",
+                None,
+            ),
+            (
+                "https://api.labarchives-gov.com",
+                "https://mynotebook.labarchives-gov.com",
+                None,
+            ),
+            (
+                "https://auapi.labarchives.com",
+                "https://au-mynotebook.labarchives.com",
+                None,
+            ),
+            (
+                "https://caapi.labarchives.com",
+                "https://ca-mynotebook.labarchives.com",
+                None,
+            ),
+            (
+                "https://euapi.labarchives.com",
+                "https://eu-mynotebook.labarchives.com",
+                None,
+            ),
+            (
+                "https://ukapi.labarchives.com",
+                "https://uk-mynotebook.labarchives.com",
+                None,
+            ),
+            (
+                "https://api.example.com/api",
+                "https://notebooks.example.com/eln",
+                "https://notebooks.example.com/eln",
+            ),
+        ],
+    )
+    def test_notebook_and_page_urls(
+        self, base_url, expected_web_url, configured_web_url
+    ):
         """Test notebooks and pages build Web UI URLs from their IDs."""
-        with Client("https://api.labarchives-gov.com", "test", "test") as client:
+        with Client(base_url, "test", "test", web_url=configured_web_url) as client:
             user = User("test-user", "test@example.com", [], client)
             notebook = Notebook(
                 NotebookInit("notebook-token", "Test Notebook", False),
@@ -61,12 +103,8 @@ class TestNotebookUnit:
             )
             page = NotebookPage("page-1", "Test Page", notebook, notebook, user)
 
-            assert notebook.url == (
-                "https://mynotebook.labarchives-gov.com/notebook-token"
-            )
-            assert page.url == (
-                "https://mynotebook.labarchives-gov.com/notebook-token/page/page-1"
-            )
+            assert notebook.url == f"{expected_web_url}/notebook-token"
+            assert page.url == f"{expected_web_url}/notebook-token/page/page-1"
 
     def test_search_is_lazy(self):
         """Test Notebook.search does not call the API until a page is requested."""


### PR DESCRIPTION
## Summary

Adds authenticated LabArchives Web UI URLs for notebooks and pages.

- Maps the supported US, government, AU, CA, EU, and UK API hosts to their canonical Web UI hosts.
- Supports custom deployments with `Client(..., web_url="https://notebooks.example.com")`.
- Rejects a Web UI URL request for an unknown API host unless that override is supplied.

## Validation

- Targeted pytest: 12 passed.
- Ruff, Pyright, ty, and strict Sphinx HTML build passed locally.
