### PR TITLE
Fix S3 attachment filename fallback

### DIFF
--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -6,6 +6,7 @@ import shutil
 import warnings
 from email.message import Message
 from io import BytesIO
+from mimetypes import guess_extension
 from pathlib import PurePosixPath
 from tempfile import TemporaryFile
 from typing import IO, TYPE_CHECKING
@@ -77,6 +78,7 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
                 if content_disposition is not None:
                     msg["Content-Disposition"] = content_disposition
 
+                mime_type = msg.get_content_type()
                 filename = msg.get_filename()
                 if filename is not None and not filename.strip():
                     filename = None
@@ -84,16 +86,17 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
                     filename = _s3_filename_from_url(attachment_stream.url)
 
                 if filename is None:
-                    filename = self.id
+                    extension = guess_extension(mime_type, strict=False) or ".bin"
+                    filename = f"{self.id}{extension}"
                     warnings.warn(
                         "Could not determine filename from API response headers "
                         "or redirected S3 URL; using attachment entry EID "
-                        f"{filename!r} as the filename.",
+                        f"{self.id!r} with MIME-derived extension {extension!r} "
+                        f"as filename {filename!r}.",
                         RuntimeWarning,
                         stacklevel=2,
                     )
 
-                mime_type = msg.get_content_type()
                 output = _make_backing_io(use_tempfile)
                 for chunk in attachment_stream:
                     output.write(chunk)

--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import warnings
 from email.message import Message
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -83,9 +84,13 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
                     filename = _s3_filename_from_url(attachment_stream.url)
 
                 if filename is None:
-                    raise ApiError(
+                    filename = self.id
+                    warnings.warn(
                         "Could not determine filename from API response headers "
-                        f"or redirected S3 URL for attachment entry {self.id!r}"
+                        "or redirected S3 URL; using attachment entry EID "
+                        f"{filename!r} as the filename.",
+                        RuntimeWarning,
+                        stacklevel=2,
                     )
 
                 mime_type = msg.get_content_type()

--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import shutil
 from email.message import Message
 from io import BytesIO
+from pathlib import PurePosixPath
 from tempfile import TemporaryFile
 from typing import IO, TYPE_CHECKING
+from urllib.parse import unquote, urlsplit
 
 from typing_extensions import override
 
@@ -21,6 +23,23 @@ if TYPE_CHECKING:
 
 def _make_backing_io(use_tempfile: bool) -> IO[bytes]:
     return TemporaryFile() if use_tempfile else BytesIO()
+
+
+def _s3_filename_from_url(url: str) -> str | None:
+    """Return a filename from a redirected Amazon S3 object URL, if valid."""
+    parsed_url = urlsplit(url)
+    if not parsed_url.hostname or not parsed_url.hostname.endswith(".amazonaws.com"):
+        return None
+
+    path = unquote(parsed_url.path)
+    if not path or path.endswith("/"):
+        return None
+
+    filename = PurePosixPath(path).name
+    if not filename.strip() or filename in {".", ".."}:
+        return None
+
+    return filename
 
 
 class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
@@ -44,26 +63,35 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
 
     def _ensure_attachment(self, use_tempfile: bool) -> None:
         if self._filedata is None or self._filedata.closed:
-            output = _make_backing_io(use_tempfile)
-
             with self._user.client.stream_api_get(
                 "entries/entry_attachment", uid=self._user.id, eid=self.id
             ) as attachment_stream:
+                headers = attachment_stream.headers
+
+                msg = Message()
+                msg["Content-Type"] = (
+                    headers.get("Content-Type") or "application/octet-stream"
+                )
+                content_disposition = headers.get("Content-Disposition")
+                if content_disposition is not None:
+                    msg["Content-Disposition"] = content_disposition
+
+                filename = msg.get_filename()
+                if filename is not None and not filename.strip():
+                    filename = None
+                if filename is None and attachment_stream.response.history:
+                    filename = _s3_filename_from_url(attachment_stream.url)
+
+                if filename is None:
+                    raise ApiError(
+                        "Could not determine filename from API response headers "
+                        f"or redirected S3 URL for attachment entry {self.id!r}"
+                    )
+
+                mime_type = msg.get_content_type()
+                output = _make_backing_io(use_tempfile)
                 for chunk in attachment_stream:
                     output.write(chunk)
-
-            headers = attachment_stream.headers
-
-            msg = Message()
-            msg["Content-Type"] = (
-                headers.get("Content-Type") or "application/octet-stream"
-            )
-            msg["Content-Disposition"] = headers.get("Content-Disposition")
-            filename = msg.get_filename()
-            mime_type = msg.get_content_type()
-
-            if filename is None:
-                raise ApiError("Could not determine filename from API response headers")
 
             self._filedata = Attachment(output, mime_type, filename, self._data)
 

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -108,10 +108,10 @@ class TestAttachmentEntryIntegration:
         assert attachment.filename == "testfile 1GiB.bin"
         assert attachment.read() == b"attachment data"
 
-    def test_attachment_entry_missing_filename_fails_before_downloading(
+    def test_attachment_entry_missing_filename_uses_eid_and_warns(
         self, client, user: User
     ):
-        """Test filename resolution errors do not consume attachment data."""
+        """Test an EID provides the filename when the response omits one."""
         entry = AttachmentEntry("eid_att", "Caption", user)
 
         mock_response = Mock()
@@ -121,12 +121,15 @@ class TestAttachmentEntryIntegration:
         }
         mock_response.history = []
         mock_response.url = "https://api.labarchives.com/api/entries/entry_attachment"
+        mock_response.iter_content.return_value = [b"attachment data"]
         client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
 
-        with pytest.raises(ApiError, match="attachment entry 'eid_att'"):
-            entry.get_attachment()
+        with pytest.warns(RuntimeWarning, match="using attachment entry EID 'eid_att'"):
+            attachment = entry.get_attachment()
 
-        mock_response.iter_content.assert_not_called()
+        assert attachment.filename == "eid_att"
+        assert attachment.read() == b"attachment data"
+        mock_response.iter_content.assert_called_once()
         mock_response.close.assert_called_once()
 
     def test_attachment_entry_content_setter(self, client, user: User):

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -108,15 +108,26 @@ class TestAttachmentEntryIntegration:
         assert attachment.filename == "testfile 1GiB.bin"
         assert attachment.read() == b"attachment data"
 
-    def test_attachment_entry_missing_filename_uses_eid_and_warns(
-        self, client, user: User
+    @pytest.mark.parametrize(
+        ("content_type", "expected_filename"),
+        [
+            ("application/pdf", "eid_att.pdf"),
+            ("application/x-unknown", "eid_att.bin"),
+        ],
+    )
+    def test_attachment_entry_missing_filename_uses_eid_and_extension(
+        self,
+        client,
+        user: User,
+        content_type: str,
+        expected_filename: str,
     ):
-        """Test an EID provides the filename when the response omits one."""
+        """Test an EID and MIME type provide a filename when the response omits one."""
         entry = AttachmentEntry("eid_att", "Caption", user)
 
         mock_response = Mock()
         mock_response.headers = {
-            "Content-Type": "application/octet-stream",
+            "Content-Type": content_type,
             "Content-Disposition": 'attachment; filename=""',
         }
         mock_response.history = []
@@ -124,10 +135,13 @@ class TestAttachmentEntryIntegration:
         mock_response.iter_content.return_value = [b"attachment data"]
         client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
 
-        with pytest.warns(RuntimeWarning, match="using attachment entry EID 'eid_att'"):
+        with pytest.warns(
+            RuntimeWarning,
+            match="using attachment entry EID 'eid_att'",
+        ):
             attachment = entry.get_attachment()
 
-        assert attachment.filename == "eid_att"
+        assert attachment.filename == expected_filename
         assert attachment.read() == b"attachment data"
         mock_response.iter_content.assert_called_once()
         mock_response.close.assert_called_once()

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from io import BytesIO
 from unittest.mock import Mock
 
+import pytest
+
 from labapi.client import StreamingResponse
 from labapi.entry.attachment import Attachment
 from labapi.entry.entries.attachment import AttachmentEntry
@@ -84,6 +86,48 @@ class TestAttachmentEntryIntegration:
         assert isinstance(attachment, Attachment)
         assert attachment.filename == "document.pdf"
         assert attachment.mime_type == "application/pdf"
+
+    def test_attachment_entry_uses_s3_redirect_path_for_filename(
+        self, client, user: User
+    ):
+        """Test S3 object keys provide a fallback attachment filename."""
+        entry = AttachmentEntry("eid_att", "Caption", user)
+
+        mock_response = Mock()
+        mock_response.headers = {"Content-Type": "application/octet-stream"}
+        mock_response.history = [Mock()]
+        mock_response.url = (
+            "https://bucket.s3-fips.us-east-1.amazonaws.com/"
+            "blobs/nbid/eid/1/testfile%201GiB.bin?X-Amz-Signature=redacted"
+        )
+        mock_response.iter_content.return_value = [b"attachment data"]
+        client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
+
+        attachment = entry.get_attachment()
+
+        assert attachment.filename == "testfile 1GiB.bin"
+        assert attachment.read() == b"attachment data"
+
+    def test_attachment_entry_missing_filename_fails_before_downloading(
+        self, client, user: User
+    ):
+        """Test filename resolution errors do not consume attachment data."""
+        entry = AttachmentEntry("eid_att", "Caption", user)
+
+        mock_response = Mock()
+        mock_response.headers = {
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": 'attachment; filename=""',
+        }
+        mock_response.history = []
+        mock_response.url = "https://api.labarchives.com/api/entries/entry_attachment"
+        client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
+
+        with pytest.raises(ApiError, match="attachment entry 'eid_att'"):
+            entry.get_attachment()
+
+        mock_response.iter_content.assert_not_called()
+        mock_response.close.assert_called_once()
 
     def test_attachment_entry_content_setter(self, client, user: User):
         """Test AttachmentEntry.content setter uploads attachment."""


### PR DESCRIPTION
## Summary

- Resolve attachment filenames from `Content-Disposition` or, after a redirect, the decoded basename of a final Amazon S3 object URL.
- When neither source yields a usable filename, derive an extension from the response MIME type and use `<eid><extension>`; use `.bin` when the MIME type has no known extension.
- Emit a `RuntimeWarning` whenever this EID-based fallback is used.
- Add regression coverage for S3 filename extraction plus known and unknown MIME-type fallbacks.

## Why

Large attachments are redirected to S3, whose response can omit `Content-Disposition`. The object key retains the filename, so the client can recover it without coupling attachment downloads to page-listing metadata. If neither source is usable, each attachment still has a stable EID and a response media type, which together produce a useful filename while allowing the download to succeed.

Fixes #283.

## Validation

- `uv run pytest tests/entry/entries/test_attachment.py` — 14 passed
- `uv run ruff check src/labapi/entry/entries/attachment.py tests/entry/entries/test_attachment.py`
- `uv run ruff format --check src/labapi/entry/entries/attachment.py tests/entry/entries/test_attachment.py`
- `uv run ty check`
