### PR TITLE
Preserve original attachment filenames

### DIFF
--- a/src/labapi/entry/collection.py
+++ b/src/labapi/entry/collection.py
@@ -211,6 +211,9 @@ class Entries(Sequence["Entry[Any]"]):
 
             eid = extract_etree(entry_tree, {"entry": {"eid": str}})["eid"]
             entry = cls(eid, data.caption, self._user)
+            entry._filename = (  # pyright: ignore[reportPrivateUsage]
+                data.filename if data.filename.strip() else None
+            )
 
         else:
             if not isinstance(data, str):

--- a/src/labapi/entry/entries/attachment.py
+++ b/src/labapi/entry/entries/attachment.py
@@ -44,6 +44,18 @@ def _s3_filename_from_url(url: str) -> str | None:
     return filename
 
 
+def _listing_filename(filename: str | None) -> str | None:
+    """Return a safe basename from attachment listing metadata."""
+    if filename is None or not filename.strip():
+        return None
+
+    basename = PurePosixPath(filename.replace("\\", "/")).name
+    if not basename.strip() or basename in {".", ".."}:
+        return None
+
+    return basename
+
+
 class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
     """Represents an attachment entry on a LabArchives page.
 
@@ -60,6 +72,8 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
         """
         super().__init__(eid, caption, user)
         self._filedata: Attachment | None = None
+        # Filename reported by the page listing (or supplied at upload time).
+        # This is more stable than a generated download filename.
         self._filename: str | None = None
         self._mime_type: str | None = None
 
@@ -79,7 +93,9 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
                     msg["Content-Disposition"] = content_disposition
 
                 mime_type = msg.get_content_type()
-                filename = msg.get_filename()
+                filename = _listing_filename(self._filename)
+                if filename is None:
+                    filename = msg.get_filename()
                 if filename is not None and not filename.strip():
                     filename = None
                 if filename is None and attachment_stream.response.history:
@@ -188,6 +204,7 @@ class AttachmentEntry(Entry[Attachment], part_type="Attachment"):
             ) from exc
 
         self._data = value.caption
+        self._filename = value.filename if value.filename.strip() else None
 
         if self._filedata:
             self._filedata.close()

--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -15,6 +15,7 @@ from typing_extensions import Self, override
 
 from labapi.entry import (
     Attachment,
+    AttachmentEntry,
     Entries,
     Entry,
     UnimplementedEntry,
@@ -100,6 +101,9 @@ class NotebookPage(AbstractTreeNode):
                         "part-type": str,
                     },
                 )
+                attachment_filename = extract_etree(
+                    entry, {"attach-file-name": str}, raise_missing=False
+                ).get("attach-file-name")
                 entry_content = extract_etree(
                     entry,
                     {"entry-data": str, "caption": str},
@@ -120,6 +124,13 @@ class NotebookPage(AbstractTreeNode):
                     data,
                     self._user,
                 )
+
+                if isinstance(entry_obj, AttachmentEntry):
+                    entry_obj._filename = (  # pyright: ignore[reportPrivateUsage]
+                        attachment_filename
+                        if attachment_filename and attachment_filename.strip()
+                        else None
+                    )
 
                 if isinstance(entry_obj, WidgetEntry):
                     pass

--- a/src/labapi/tree/search.py
+++ b/src/labapi/tree/search.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from labapi.entry import Entry
+from labapi.entry import AttachmentEntry, Entry
 from labapi.util import extract_etree
 
 if TYPE_CHECKING:
@@ -80,6 +80,9 @@ class EntrySearch:
         entries: list[Entry[Any]] = []
         for entry_element in response.findall("./entries/entry"):
             entry_fields = extract_etree(entry_element, {"eid": str, "part-type": str})
+            attachment_filename = extract_etree(
+                entry_element, {"attach-file-name": str}, raise_missing=False
+            ).get("attach-file-name")
 
             entry_data = entry_element.find("./entry-data")
             caption = entry_element.find("./caption")
@@ -98,14 +101,20 @@ class EntrySearch:
             ):
                 data = caption.text
 
-            entries.append(
-                Entry.from_part_type(
-                    entry_fields["part-type"],
-                    entry_fields["eid"],
-                    data,
-                    self._notebook.user,
-                )
+            entry = Entry.from_part_type(
+                entry_fields["part-type"],
+                entry_fields["eid"],
+                data,
+                self._notebook.user,
             )
+            if isinstance(entry, AttachmentEntry):
+                entry._filename = (  # pyright: ignore[reportPrivateUsage]
+                    attachment_filename
+                    if attachment_filename and attachment_filename.strip()
+                    else None
+                )
+
+            entries.append(entry)
 
         page = EntrySearchPage(
             page_size=self._page_size,

--- a/tests/entry/entries/test_attachment.py
+++ b/tests/entry/entries/test_attachment.py
@@ -66,6 +66,38 @@ class TestAttachmentEntryIntegration:
             "entries/entry_attachment", uid=user.id, eid="eid_att"
         )
 
+    def test_attachment_entry_prefers_listing_filename(self, client, user: User):
+        """A page-listing filename takes precedence over download headers."""
+        entry = AttachmentEntry("eid_att", "Caption", user)
+        entry._filename = "original.txt"  # pyright: ignore[reportPrivateUsage]
+        mock_response = Mock()
+        mock_response.headers = {
+            "Content-Type": "text/plain",
+            "Content-Disposition": 'attachment; filename="generated.txt"',
+        }
+        mock_response.iter_content.return_value = [b"content"]
+        client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
+
+        assert entry.get_attachment().filename == "original.txt"
+
+    def test_attachment_entry_uses_basename_from_listing_filename(
+        self, client, user: User
+    ):
+        """A path-like listing filename is reduced to its basename."""
+        entry = AttachmentEntry("eid_att", "Caption", user)
+        entry._filename = (  # pyright: ignore[reportPrivateUsage]
+            "uploaded\\from/browser/original.txt"
+        )
+        mock_response = Mock()
+        mock_response.headers = {
+            "Content-Type": "text/plain",
+            "Content-Disposition": 'attachment; filename="generated.txt"',
+        }
+        mock_response.iter_content.return_value = [b"content"]
+        client.stream_api_get = Mock(return_value=StreamingResponse(mock_response))
+
+        assert entry.get_attachment().filename == "original.txt"
+
     def test_attachment_entry_content_getter(self, client, user: User):
         """Test AttachmentEntry.content getter returns attachment."""
         entry = AttachmentEntry("eid_att", "Caption", user)
@@ -149,6 +181,28 @@ class TestAttachmentEntryIntegration:
     def test_attachment_entry_content_setter(self, client, user: User):
         """Test AttachmentEntry.content setter uploads attachment."""
         entry = AttachmentEntry("eid_att", "Old caption", user)
+        entry._filename = "old_file.txt"  # pyright: ignore[reportPrivateUsage]
+
+        old_response = Mock()
+        old_response.headers = {
+            "Content-Type": "text/plain",
+            "Content-Disposition": 'attachment; filename="generated_old.txt"',
+        }
+        old_response.iter_content.return_value = [b"Old file content"]
+        new_response = Mock()
+        new_response.headers = {
+            "Content-Type": "text/plain",
+            "Content-Disposition": 'attachment; filename="generated_new.txt"',
+        }
+        new_response.iter_content.return_value = [b"New file content"]
+        client.stream_api_get = Mock(
+            side_effect=[
+                StreamingResponse(old_response),
+                StreamingResponse(new_response),
+            ]
+        )
+
+        assert entry.get_attachment().read() == b"Old file content"
 
         # Create a new attachment to upload
         backing = BytesIO(b"New file content")
@@ -174,6 +228,11 @@ class TestAttachmentEntryIntegration:
         assert api_call[1]["filename"] == "new_file.txt"
         assert api_call[1]["caption"] == "New caption"
         assert api_call[1]["eid"] == "eid_att"
+        assert entry._filename == "new_file.txt"  # pyright: ignore[reportPrivateUsage]
+        updated_attachment = entry.get_attachment()
+        assert updated_attachment.filename == "new_file.txt"
+        assert updated_attachment.read() == b"New file content"
+        assert client.stream_api_get.call_count == 2
 
     def test_attachment_entry_content_setter_rewinds_seekable_stream(
         self, client, user: User
@@ -205,6 +264,11 @@ class TestAttachmentEntryIntegration:
     ):
         """Test 4999 attachment update errors include actionable context."""
         entry = AttachmentEntry("eid_att", "Old caption", user)
+        entry._filename = "old_file.txt"  # pyright: ignore[reportPrivateUsage]
+        cached_attachment = Attachment(
+            BytesIO(b"Old file content"), "text/plain", "old_file.txt", "Old caption"
+        )
+        entry._filedata = cached_attachment  # pyright: ignore[reportPrivateUsage]
         attachment = Attachment(
             BytesIO(b"New file content"),
             "text/plain",
@@ -229,6 +293,9 @@ class TestAttachmentEntryIntegration:
         assert "LabArchives returned [4999] Unknown Error" in message
         assert "retry with a fresh Attachment object" in message
         assert entry.caption == "Old caption"
+        assert entry._filename == "old_file.txt"  # pyright: ignore[reportPrivateUsage]
+        assert entry._filedata is cached_attachment  # pyright: ignore[reportPrivateUsage]
+        assert not cached_attachment.closed
         api_call = client.pop_api_call()
         assert api_call[0] == "entries/update_attachment"
         assert api_call[1]["eid"] == "eid_att"
@@ -239,6 +306,11 @@ class TestAttachmentEntryIntegration:
     ):
         """Test non-4999 attachment update errors pass through unchanged."""
         entry = AttachmentEntry("eid_att", "Old caption", user)
+        entry._filename = "old_file.txt"  # pyright: ignore[reportPrivateUsage]
+        cached_attachment = Attachment(
+            BytesIO(b"Old file content"), "text/plain", "old_file.txt", "Old caption"
+        )
+        entry._filedata = cached_attachment  # pyright: ignore[reportPrivateUsage]
         attachment = Attachment(
             BytesIO(b"New file content"),
             "text/plain",
@@ -256,6 +328,10 @@ class TestAttachmentEntryIntegration:
             raise AssertionError("Expected ApiError")
 
         assert preserved_error is raw_error
+        assert entry.caption == "Old caption"
+        assert entry._filename == "old_file.txt"  # pyright: ignore[reportPrivateUsage]
+        assert entry._filedata is cached_attachment  # pyright: ignore[reportPrivateUsage]
+        assert not cached_attachment.closed
         api_call = client.pop_api_call()
         assert api_call[0] == "entries/update_attachment"
         assert api_call[1]["eid"] == "eid_att"

--- a/tests/entry/test_collection.py
+++ b/tests/entry/test_collection.py
@@ -281,6 +281,7 @@ class TestEntriesIntegration:
         assert isinstance(entry, AttachmentEntry)
         assert entry.id == "new_attachment_eid"
         assert entry.caption == "Test file"
+        assert entry._filename == "test.txt"  # pyright: ignore[reportPrivateUsage]
         assert len(entries) == 1
 
         # Verify API call

--- a/tests/tree/test_page.py
+++ b/tests/tree/test_page.py
@@ -366,6 +366,29 @@ class TestNotebookPageIntegration:
         _ = client.pop_api_call()
         client.clear_api_calls()
 
+    def test_page_entries_preserve_attachment_filename(
+        self, client, notebook_tree: Notebook
+    ):
+        """Attachment entries retain the filename from the page listing."""
+        page = notebook_tree[Index.Id : "page-1"].as_page()
+        client.clear_api_calls()
+        client.api_response = client.entries_response(
+            client.entry_xml(
+                "attachment-1",
+                part_type="Attachment",
+                attach_file_name="original.txt",
+                entry_data="Caption",
+            ),
+            include_response=False,
+        )
+
+        entry = page.entries[0]
+
+        assert isinstance(entry, AttachmentEntry)
+        assert entry._filename == "original.txt"  # pyright: ignore[reportPrivateUsage]
+        _ = client.pop_api_call()
+        client.clear_api_calls()
+
     def test_page_entries_preserve_widget_entry_without_warning(
         self, client, notebook_tree: Notebook
     ):

--- a/tests/tree/test_search.py
+++ b/tests/tree/test_search.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from lxml.etree import fromstring
 
+from labapi.entry import AttachmentEntry
 from labapi.tree.search import EntrySearch, EntrySearchPage
 
 
@@ -108,3 +109,29 @@ class TestEntrySearchIteration:
         search = _make_search([2], page_size=2)
         with pytest.raises(IndexError, match="out of range"):
             search.page(1)
+
+    def test_attachment_result_preserves_listing_filename(self) -> None:
+        """Attachment search results retain their original filename metadata."""
+        response = fromstring(
+            "<response>"
+            "<results><total-found type='integer'>1</total-found>"
+            "<total-returned type='integer'>1</total-returned></results>"
+            "<entries><entry><eid>eid_att</eid><part-type>Attachment</part-type>"
+            "<caption>Caption</caption><attach-file-name>original.txt</attach-file-name>"
+            "</entry></entries></response>"
+        )
+
+        class FakeUser:
+            def api_get(self, _method: str, **_kw: object) -> object:
+                return response
+
+        class FakeNotebook:
+            id = "nbid"
+            user = FakeUser()
+
+        result = EntrySearch(FakeNotebook(), "q", page_size=2).page(0)  # type: ignore[arg-type]
+
+        assert len(result.entries) == 1
+        attachment = result.entries[0]
+        assert isinstance(attachment, AttachmentEntry)
+        assert attachment._filename == "original.txt"  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary

- preserve LabArchives `attach-file-name` metadata on attachment entries loaded from pages and search results
- retain upload filenames on newly created and updated attachment entries
- prefer that stable original basename over generated download headers, while keeping the existing header/S3/EID fallbacks

## Why

LabArchives may return generated filenames from the attachment download endpoint, and S3-backed downloads do not expose all upload metadata. Page and search listings do expose the original filename, but `labapi` discarded it before this change.

## Verification

- `uv run --python 3.10 pytest --no-cov -q tests/entry/entries/test_attachment.py tests/entry/test_collection.py tests/tree/test_page.py tests/tree/test_search.py` — 61 passed
- `uv run --python 3.10 pytest --no-cov -q -k 'not test_browser_detection_loads_dotenv_before_reading_env'` — 416 passed, 1 skipped, 6 deselected
- Ruff check/format and Pyright pass
- live download from `test-for-christoph/upload-size-test` preserved `test_0050MiB.bin`
- independent correctness and test-coverage reviews completed; findings addressed

Fixes #287
