### PR TITLE
Expose entry lifecycle metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ details that affect development workflows.
 
 ### Added
 
+- Entries now expose optional read-only creation, update, and version metadata.
 - `Client` request methods accept a `timeout` parameter.
 - `Notebook.backup()` downloads a notebook's native LabArchives backup archive
   or JSON response, with options to omit attachment payloads.

--- a/src/labapi/entry/entries/base.py
+++ b/src/labapi/entry/entries/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from inspect import isabstract
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar, cast
 
@@ -27,6 +28,18 @@ class _MetaEntryFactory(Protocol):
 
 
 _entries_registry: dict[str, type[Entry[Any]]] = {}
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse a timezone-aware ISO 8601 timestamp from a LabArchives response."""
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+
+    result = datetime.fromisoformat(value)
+    if result.tzinfo is None or result.utcoffset() is None:
+        raise ValueError("timestamp must include a timezone offset")
+
+    return result
 
 
 class Entry(Generic[T], ABC):
@@ -67,7 +80,16 @@ class Entry(Generic[T], ABC):
         return _entries_registry[part_type]
 
     @staticmethod
-    def from_part_type(part_type: str, eid: str, data: str, user: User) -> Entry[Any]:
+    def from_part_type(
+        part_type: str,
+        eid: str,
+        data: str,
+        user: User,
+        *,
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+        version: int | None = None,
+    ) -> Entry[Any]:
         """Create an entry instance for a LabArchives part type.
 
         This method takes a part type string and returns the corresponding
@@ -82,6 +104,9 @@ class Entry(Generic[T], ABC):
         :param data: The entry data. For text-based entries, this is the text content.
                     For attachment entries, this is the caption.
         :param user: The authenticated user associated with this entry.
+        :param created_at: The timestamp when the entry was created, if supplied by the API.
+        :param updated_at: The timestamp when the entry was last updated, if supplied by the API.
+        :param version: The API version number for the entry, if supplied by the API.
         :returns: An entry instance of the appropriate type.
         """
         klass = _entries_registry.get(part_type)
@@ -89,12 +114,16 @@ class Entry(Generic[T], ABC):
         if klass is None:
             from .unknown import UnknownEntry
 
-            return UnknownEntry(eid, data, user, part_type=part_type)
+            entry = UnknownEntry(eid, data, user, part_type=part_type)
+        elif klass._is_meta:
+            entry = cast(_MetaEntryFactory, klass)(eid, data, user, part_type=part_type)
+        else:
+            entry = cast(_EntryFactory, klass)(eid, data, user)
 
-        if klass._is_meta:
-            return cast(_MetaEntryFactory, klass)(eid, data, user, part_type=part_type)
-
-        return cast(_EntryFactory, klass)(eid, data, user)
+        entry._created_at = created_at
+        entry._updated_at = updated_at
+        entry._version = version
+        return entry
 
     # TODO perms
     def __init__(
@@ -112,6 +141,9 @@ class Entry(Generic[T], ABC):
         self._id = eid
         self._data = data
         self._user = user
+        self._created_at: datetime | None = None
+        self._updated_at: datetime | None = None
+        self._version: int | None = None
 
     def __init_subclass__(
         cls,
@@ -149,6 +181,21 @@ class Entry(Generic[T], ABC):
         :returns: A string representing the entry's type (e.g., "text entry", "Attachment").
         """
         return self._part_type
+
+    @property
+    def created_at(self) -> datetime | None:
+        """Return when this entry was created, if supplied by the API."""
+        return self._created_at
+
+    @property
+    def updated_at(self) -> datetime | None:
+        """Return when this entry was last updated, if supplied by the API."""
+        return self._updated_at
+
+    @property
+    def version(self) -> int | None:
+        """Return this entry's API version number, if supplied by the API."""
+        return self._version
 
     @property
     @abstractmethod

--- a/src/labapi/tree/page.py
+++ b/src/labapi/tree/page.py
@@ -21,6 +21,7 @@ from labapi.entry import (
     UnknownEntry,
     WidgetEntry,
 )
+from labapi.entry.entries.base import _parse_iso_datetime
 from labapi.util import InsertBehavior, extract_etree
 
 from .mixins import AbstractTreeContainer, AbstractTreeNode
@@ -100,6 +101,15 @@ class NotebookPage(AbstractTreeNode):
                         "part-type": str,
                     },
                 )
+                entry_metadata = extract_etree(
+                    entry,
+                    {
+                        "created-at": _parse_iso_datetime,
+                        "updated-at": _parse_iso_datetime,
+                        "version": int,
+                    },
+                    raise_missing=False,
+                )
                 entry_content = extract_etree(
                     entry,
                     {"entry-data": str, "caption": str},
@@ -119,6 +129,9 @@ class NotebookPage(AbstractTreeNode):
                     cast(str, entry_fields["eid"]),
                     data,
                     self._user,
+                    created_at=entry_metadata.get("created-at"),
+                    updated_at=entry_metadata.get("updated-at"),
+                    version=entry_metadata.get("version"),
                 )
 
                 if isinstance(entry_obj, WidgetEntry):

--- a/src/labapi/tree/search.py
+++ b/src/labapi/tree/search.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from labapi.entry import Entry
+from labapi.entry.entries.base import _parse_iso_datetime
 from labapi.util import extract_etree
 
 if TYPE_CHECKING:
@@ -80,6 +81,15 @@ class EntrySearch:
         entries: list[Entry[Any]] = []
         for entry_element in response.findall("./entries/entry"):
             entry_fields = extract_etree(entry_element, {"eid": str, "part-type": str})
+            entry_metadata = extract_etree(
+                entry_element,
+                {
+                    "created-at": _parse_iso_datetime,
+                    "updated-at": _parse_iso_datetime,
+                    "version": int,
+                },
+                raise_missing=False,
+            )
 
             entry_data = entry_element.find("./entry-data")
             caption = entry_element.find("./caption")
@@ -104,6 +114,9 @@ class EntrySearch:
                     entry_fields["eid"],
                     data,
                     self._notebook.user,
+                    created_at=entry_metadata.get("created-at"),
+                    updated_at=entry_metadata.get("updated-at"),
+                    version=entry_metadata.get("version"),
                 )
             )
 

--- a/tests/entry/entries/test_base.py
+++ b/tests/entry/entries/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -21,6 +22,14 @@ class TestEntryUnit:
         """Test Entry stores and exposes its ID."""
         entry = TextEntry("eid_test", "<p>Content</p>", Mock(spec=User))
         assert entry.id == "eid_test"
+
+    def test_direct_constructor_defaults_metadata_to_none(self):
+        """Test existing three-argument constructors leave metadata unset."""
+        entry = TextEntry("eid_test", "<p>Content</p>", Mock(spec=User))
+
+        assert entry.created_at is None
+        assert entry.updated_at is None
+        assert entry.version is None
 
     def test_entry_content_type(self):
         """Test Entry exposes the correct content_type for its class."""
@@ -115,3 +124,22 @@ class TestEntryIntegration:
         assert isinstance(entry, UnknownEntry)
         assert entry.content_type == "unknown_type"
         assert entry.content == "Data"
+
+    def test_entry_from_part_type_applies_optional_metadata(self, user: User):
+        """Test factory metadata is assigned without changing subclass constructors."""
+        created_at = datetime(2026, 7, 29, 22, 12, 57, tzinfo=timezone.utc)
+        updated_at = datetime(2026, 7, 30, 1, 2, 3, tzinfo=timezone.utc)
+
+        entry = Entry.from_part_type(
+            "text entry",
+            "eid_123",
+            "data",
+            user,
+            created_at=created_at,
+            updated_at=updated_at,
+            version=1,
+        )
+
+        assert entry.created_at == created_at
+        assert entry.updated_at == updated_at
+        assert entry.version == 1

--- a/tests/tree/test_page.py
+++ b/tests/tree/test_page.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import warnings
+from datetime import datetime, timezone
 from io import BytesIO
 from unittest.mock import Mock
 
 import pytest
 
-from labapi import Index, Notebook, NotebookPage
+from labapi import ExtractionError, Index, Notebook, NotebookPage
 from labapi.entry import Attachment, AttachmentEntry, Entries, UnknownEntry, WidgetEntry
 from labapi.user import User
 
@@ -224,12 +225,65 @@ class TestNotebookPageIntegration:
 
         assert isinstance(entries, Entries)
         assert len(entries) == 2
+        assert entries[0].created_at is None
+        assert entries[0].updated_at is None
+        assert entries[0].version is None
 
         api_call = client.pop_api_call()
         assert api_call[0] == "tree_tools/get_entries_for_page"
         assert api_call[1]["page_tree_id"] == "page-1"
         assert api_call[1]["nbid"] == notebook_tree.id
         assert api_call[1]["entry_data"] is True
+        client.clear_api_calls()
+
+    def test_page_entries_extract_optional_metadata(
+        self, client, notebook_tree: Notebook
+    ):
+        """Test page entries preserve API timestamps and versions."""
+        page = notebook_tree[Index.Id : "page-1"].as_page()
+        client.clear_api_calls()
+        client.api_response = client.entries_response(
+            client.xml(
+                "entry",
+                client.xml("eid", "entry_1"),
+                client.xml("part-type", "text entry"),
+                client.xml("created-at", "2026-07-29T22:12:57Z"),
+                client.xml("updated-at", "2026-07-30T01:02:03Z"),
+                client.xml("version", "1"),
+                client.xml("entry-data", "<p>Test content</p>"),
+            ),
+            include_response=False,
+        )
+
+        entry = page.entries[0]
+
+        assert entry.created_at == datetime(
+            2026, 7, 29, 22, 12, 57, tzinfo=timezone.utc
+        )
+        assert entry.updated_at == datetime(2026, 7, 30, 1, 2, 3, tzinfo=timezone.utc)
+        assert entry.version == 1
+        client.clear_api_calls()
+
+    @pytest.mark.parametrize("timestamp", ["not-a-timestamp", "2026-07-29T22:12:57"])
+    def test_page_entries_reject_invalid_metadata_timestamps(
+        self, client, notebook_tree: Notebook, timestamp: str
+    ):
+        """Test malformed and timezone-naive timestamps surface as extraction errors."""
+        page = notebook_tree[Index.Id : "page-1"].as_page()
+        client.api_response = client.entries_response(
+            client.xml(
+                "entry",
+                client.xml("eid", "entry_1"),
+                client.xml("part-type", "text entry"),
+                client.xml("created-at", timestamp),
+                client.xml("entry-data", "<p>Test content</p>"),
+            ),
+            include_response=False,
+        )
+
+        with pytest.raises(ExtractionError, match="_parse_iso_datetime"):
+            _ = page.entries
+
         client.clear_api_calls()
 
     def test_page_entries_caching(self, client, notebook_tree: Notebook):

--- a/tests/tree/test_search.py
+++ b/tests/tree/test_search.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from lxml.etree import fromstring
 
 from labapi.tree.search import EntrySearch, EntrySearchPage
 
 
-def _search_response(*, total_found: int, total_returned: int) -> object:
+def _search_response(
+    *, total_found: int, total_returned: int, entries_xml: str = ""
+) -> object:
     """Build a minimal entry-search XML response."""
     return fromstring(
         f"<response>"
@@ -16,13 +20,17 @@ def _search_response(*, total_found: int, total_returned: int) -> object:
         f"<total-found type='integer'>{total_found}</total-found>"
         f"<total-returned type='integer'>{total_returned}</total-returned>"
         f"</results>"
-        f"<entries/>"
+        f"<entries>{entries_xml}</entries>"
         f"</response>"
     )
 
 
 def _make_search(
-    returned_by_page: list[int], *, page_size: int = 2, total_found: int | None = None
+    returned_by_page: list[int],
+    *,
+    page_size: int = 2,
+    total_found: int | None = None,
+    entries_xml_by_page: dict[int, str] | None = None,
 ) -> EntrySearch:
     """Build an EntrySearch backed by a fake notebook/user.
 
@@ -43,7 +51,14 @@ def _make_search(
                 if page_number < len(returned_by_page)
                 else 0
             )
-            return _search_response(total_found=total_found, total_returned=returned)
+            entries_xml = ""
+            if entries_xml_by_page is not None:
+                entries_xml = entries_xml_by_page.get(page_number, "")
+            return _search_response(
+                total_found=total_found,
+                total_returned=returned,
+                entries_xml=entries_xml,
+            )
 
     class FakeNotebook:
         id = "nbid"
@@ -108,3 +123,26 @@ class TestEntrySearchIteration:
         search = _make_search([2], page_size=2)
         with pytest.raises(IndexError, match="out of range"):
             search.page(1)
+
+    def test_page_extracts_optional_entry_metadata(self) -> None:
+        """Search results preserve timezone-aware timestamps and versions."""
+        search = _make_search(
+            [1],
+            page_size=1,
+            entries_xml_by_page={
+                0: (
+                    "<entry><eid>entry_1</eid><part-type>text entry</part-type>"
+                    "<created-at>2026-07-29T22:12:57Z</created-at>"
+                    "<updated-at>2026-07-30T01:02:03Z</updated-at>"
+                    "<version>1</version><entry-data>Test content</entry-data></entry>"
+                )
+            },
+        )
+
+        entry = search.page(0).entries[0]
+
+        assert entry.created_at == datetime(
+            2026, 7, 29, 22, 12, 57, tzinfo=timezone.utc
+        )
+        assert entry.updated_at == datetime(2026, 7, 30, 1, 2, 3, tzinfo=timezone.utc)
+        assert entry.version == 1


### PR DESCRIPTION
## Summary

- expose optional read-only `Entry.created_at`, `Entry.updated_at`, and `Entry.version` properties
- populate lifecycle metadata from page-entry and entry-search responses
- parse timestamps as timezone-aware `datetime` values and versions as integers
- preserve existing three-argument entry constructors and return `None` when metadata is absent

## Why

LabArchives already returns authoritative `created-at`, `updated-at`, and `version` fields, but `labapi` discarded them. Callers otherwise have to parse raw XML or infer lifecycle information from unreliable attachment download and S3 metadata.

## Impact

Callers can use structured entry metadata for synchronization, provenance, audit displays, cache invalidation, and exports. Malformed or timezone-naive API timestamps fail as extraction errors instead of producing ambiguous values.

## Verification

- focused entry/page/search suite: 49 passed
- broader suite excluding the known order-dependent browser-environment test: 418 passed, 1 skipped, 6 deselected
- Ruff check/format and full-project Pyright pass
- live `test-for-christoph/upload-size-test` page returned aware `datetime`, aware `datetime`, and `int` values through `page.entries`
- independent correctness/API compatibility review found no material issues

Fixes #288
